### PR TITLE
Fix broken canonical URLs and internal links on glossary pages

### DIFF
--- a/src/_includes/layouts/base.hbs
+++ b/src/_includes/layouts/base.hbs
@@ -7,7 +7,7 @@
     <meta name="robots" content="index, follow">
     <meta name="author" content="Spike.sh">
     <meta name="copyright" content="Spike.sh">
-    <link rel="canonical" href="https://spike.sh/{{#if term}}/glossary/{{page.fileSlug}}{{else}}glossary{{/if}}">
+    <link rel="canonical" href="https://spike.sh/{{#if term}}glossary/{{page.fileSlug}}{{else}}glossary{{/if}}">
 
     {{!-- Phone tags --}}
     <link rel="icon" type="image/png" sizes="24x24" href="https://cdn.spike.sh/logos/spike-badge-icon.png">

--- a/src/_includes/layouts/base.hbs
+++ b/src/_includes/layouts/base.hbs
@@ -7,7 +7,7 @@
     <meta name="robots" content="index, follow">
     <meta name="author" content="Spike.sh">
     <meta name="copyright" content="Spike.sh">
-    <link rel="canonical" href="https://spike.sh/{{#if term}}glossary/{{page.fileSlug}}{{else}}glossary{{/if}}">
+    <link rel="canonical" href="https://spike.sh/{{#if term}}glossary/{{page.fileSlug}}{{else}}glossary/{{/if}}">
 
     {{!-- Phone tags --}}
     <link rel="icon" type="image/png" sizes="24x24" href="https://cdn.spike.sh/logos/spike-badge-icon.png">

--- a/src/_includes/layouts/glossary-item.hbs
+++ b/src/_includes/layouts/glossary-item.hbs
@@ -85,7 +85,7 @@ layout: layouts/base.hbs
                         <div class=" related-card">
                             <h3>{{this.title}}</h3>
                             <p>{{this.excerpt}}</p>
-                            <a href="/{{this.slug}}/" class="card-link"></a>
+                            <a href="/glossary/{{this.slug}}/" class="card-link"></a>
                         </div>
                     </div>
                     {{/each}}
@@ -95,7 +95,7 @@ layout: layouts/base.hbs
                         <div class="glossary-card">
                             <h3>{{this.title}}</h3>
                             <p>{{truncate this.excerpt 150}}</p>
-                            <a href="/{{this.slug}}/" class="card-link" data-slug="{{this.slug}}"></a>
+                            <a href="/glossary/{{this.slug}}/" class="card-link" data-slug="{{this.slug}}"></a>
                         </div>
                     </div>
                     {{/each}}

--- a/src/critical-service.md
+++ b/src/critical-service.md
@@ -1,3 +1,8 @@
+---
+excerpt: A critical service is any system or application essential for business operations. If it fails, it causes major disruption or financial loss.
+term: Critical Service
+---
+
 ## What Is Critical Service
 
 A critical service is any system or application essential for business operations. If it fails, it causes major disruption or financial loss.

--- a/src/cyber-physical-systems-incidents.md
+++ b/src/cyber-physical-systems-incidents.md
@@ -1,3 +1,8 @@
+---
+excerpt: Cyber Physical Systems Incidents are events that affect systems where digital and physical components interact. These incidents can impact both digital operations and physical infrastructure, potentially causing real-world consequences.
+term: Cyber Physical Systems Incidents
+---
+
 ## What Are Cyber Physical Systems Incidents
 
 Cyber Physical Systems Incidents are events that affect systems where digital and physical components interact. These incidents can impact both digital operations and physical infrastructure, potentially causing real-world consequences.


### PR DESCRIPTION
## Summary
Found during an SEO audit (Ahrefs Site Audit flagged 541+ broken links/canonicals across glossary pages, all tracing back to these bugs):

**1. Canonical tag double-slash regression**
The canonical URL bug was already partially fixed in `be94f34` ("fix: seo: the canonical url condition was wrong"), but that fix introduced a new issue — an extra leading slash producing `https://spike.sh//glossary/{term}` instead of `https://spike.sh/glossary/{term}`. Corrected to the single-slash form.

**2. Glossary index canonical missing its trailing slash**
The index page's own canonical (the `{{else}}` branch) pointed to `https://spike.sh/glossary` (no trailing slash), which 301-redirects to the real URL `https://spike.sh/glossary/`. A canonical should point to the final URL, not one that redirects. Fixed to include the trailing slash.

**3. "Further reading" related-term links missing `/glossary/` prefix**
Every glossary page shows 3 "related term" cards at the bottom (via either the `related` front-matter field or the `getNextTerms` fallback). Both code paths link to `/{{slug}}/` instead of `/glossary/{{slug}}/`. Since this renders on every page, this is the actual source of the bulk of the 404s the audit found — not just the canonical tag.

**4. Two glossary pages missing front matter entirely**
`critical-service.md` and `cyber-physical-systems-incidents.md` have complete, well-written content but no YAML front matter (`term`/`excerpt`). Without `term` set, the canonical falls back to the glossary index and the page title/H1 render empty. Added the missing front matter using each page's own existing content — no new content written.

Together, #1, #2, and #4 account for all 4 pages in the original "canonical points to redirect" audit finding.

## Test plan
- [x] Ran a local build (`npx eleventy`) — confirmed in the output:
  - `/bug/` canonical now renders as `https://spike.sh/glossary/bug` (was `https://spike.sh/bug` before, `https://spike.sh//glossary/bug` after the previous fix)
  - `/glossary/` index canonical now renders as `https://spike.sh/glossary/` (was `https://spike.sh/glossary`, no slash)
  - "Further reading" cards now link to `/glossary/{slug}/` correctly
  - `/critical-service/` and `/cyber-physical-systems-incidents/` now render their correct title and canonical instead of falling back to the glossary index
- [ ] Spot check a few glossary pages after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)