### PR TITLE
Fix schema.org validation errors on glossary pages

### DIFF
--- a/src/_includes/layouts/base.hbs
+++ b/src/_includes/layouts/base.hbs
@@ -157,11 +157,7 @@
             "name": "Incident Response",
             "description": "The process of identifying, analyzing, and responding to incidents in IT systems and services."
         },
-        "numberOfItems": "500+",
-        "mainEntity": {
-            "@type": "ItemList",
-            "itemListElement": "500+ terms related to incident response and management"
-        }
+        "numberOfItems": 500
     }
     </script>
 


### PR DESCRIPTION
## Summary
Found during an SEO audit: Ahrefs flagged 551 glossary pages with schema.org structured data validation errors, all coming from the same shared `CollectionPage` JSON-LD block in the base layout — so this is one template fix, not 551 separate ones.

Two issues in the block:
1. `numberOfItems: "500+"` — should be an integer. Changed to `numberOfItems: 500`.
2. `mainEntity.itemListElement` was a plain sentence ("500+ terms related to incident response and management") rather than an actual list — invalid regardless of the type error. Removed the `mainEntity` block rather than fabricating a real item list. Happy to add a proper `ItemList` back if there's a real use case for enumerating terms here — wanted to flag the call rather than guess.

## Test plan
- [x] Ran a local build (`npx eleventy`) — confirmed `numberOfItems` now renders as an integer (`500`) in the output HTML
- [ ] Validate a live glossary page with Google's Rich Results Test after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)