### PR TITLE
Fix trailing-slash canonical URLs and remaining schema.org error

### DIFF
--- a/src/_includes/layouts/base.hbs
+++ b/src/_includes/layouts/base.hbs
@@ -152,11 +152,6 @@
         "name": "Incident Response Glossary",
         "description": "A curated collection of 500+ terms to help teams understand key concepts in incident management, monitoring, on-call response, and DevOps.",
         "url": "https://spike.sh/glossary",
-        "about": {
-            "@type": "Thing",
-            "name": "Incident Response",
-            "description": "The process of identifying, analyzing, and responding to incidents in IT systems and services."
-        },
         "numberOfItems": 500
     }
     </script>

--- a/src/_includes/layouts/base.hbs
+++ b/src/_includes/layouts/base.hbs
@@ -7,7 +7,7 @@
     <meta name="robots" content="index, follow">
     <meta name="author" content="Spike.sh">
     <meta name="copyright" content="Spike.sh">
-    <link rel="canonical" href="https://spike.sh/{{#if term}}glossary/{{page.fileSlug}}{{else}}glossary/{{/if}}">
+    <link rel="canonical" href="https://spike.sh/{{#if term}}glossary/{{page.fileSlug}}/{{else}}glossary/{{/if}}">
 
     {{!-- Phone tags --}}
     <link rel="icon" type="image/png" sizes="24x24" href="https://cdn.spike.sh/logos/spike-badge-icon.png">
@@ -47,7 +47,7 @@
         <!-- Open Graph / Facebook -->
         <meta property="og:title" content="{{term}} in Incident Response Explained">
         <meta property="og:description" content="Learn what {{term}} means in incident response, why it matters, and how it impacts teams.">
-        <meta property="og:url" content="https://spike.sh/{{page.fileSlug}}">
+        <meta property="og:url" content="https://spike.sh/glossary/{{page.fileSlug}}/">
         <meta property="og:type" content="article">
         <meta property="og:image" content="https://cdn.spike.sh/glossary/{{page.fileSlug}}.png">
         <meta property="og:image:width" content="1200">
@@ -55,7 +55,7 @@
 
         {{!-- Twitter --}}
         <meta name="twitter:card" content="summary_large_image">
-        <meta name="twitter:url" content="https://spike.sh/{{page.fileSlug}}">
+        <meta name="twitter:url" content="https://spike.sh/glossary/{{page.fileSlug}}/">
         <meta name="twitter:title" content="{{term}} in Incident Response Explained">
         <meta name="twitter:description" content="Learn what {{term}} means in incident response, why it matters, and how it impacts teams.">
         <meta name="twitter:image" content="https://cdn.spike.sh/glossary/{{page.fileSlug}}.png">


### PR DESCRIPTION
## Summary
Two follow-up fixes, both caught while investigating today's re-run of the SEO audit, both in the same file (`base.hbs`).

**1. Missing trailing slash on canonical/og:url/twitter:url (follow-up to #12)**

#12 fixed the canonical's double-slash bug and missing `/glossary/` prefix, but the individual term-page branch still built the URL *without* a trailing slash (`https://spike.sh/glossary/{slug}` instead of `.../{slug}/`), while the actual page is served at the trailing-slash URL. This showed up in the audit as:
- "Broken redirect" — 541 pages (new)
- "Canonical points to redirect" — jumped from 4 to 547

Confirmed live: `spike.sh/glossary/bug/` (with slash) → 200 OK reliably. `spike.sh/glossary/bug` (no slash) → sometimes 308 redirects correctly, sometimes Cloudflare 520/522 (origin error) — intermittent, not just cosmetic.

Same exact bug existed independently in `og:url` and `twitter:url` (missing both the `/glossary/` prefix and the trailing slash) — never part of the original audit finding, fixed here too since it's the same one-line change in the same file.

**2. Remaining schema.org validation error (follow-up to #13)**

#13 fixed `numberOfItems` (string → integer) and removed the malformed `mainEntity` block, but the `CollectionPage` schema originally had **two** separate validation errors, and only one was confirmed fixed — "Unexpected property for CollectionPage" was guessed at, not verified. Checked live after #13 deployed: the error is still present, caused by the `about` property, which isn't a recognized property for `CollectionPage`. Removed it (same reasoning as `mainEntity` — supplementary description text, not essential).

## Test plan
- [x] Local build confirms canonical, `og:url`, `twitter:url` for `/bug/` all render as `https://spike.sh/glossary/bug/`
- [x] Local build confirms `CollectionPage` schema no longer includes `about`
- [ ] Spot check a few glossary pages after deploy — confirm no redirect on canonical/og/twitter, and validate structured data with Google's Rich Results Test

🤖 Generated with [Claude Code](https://claude.com/claude-code)