### PR TITLE
Add llms.txt index for the glossary

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -49,6 +49,9 @@ module.exports = function(eleventyConfig) {
   
   // Pass-through the compiled CSS
   eleventyConfig.addPassthroughCopy("src/assets/css");
+
+  // Pass-through the llms.txt index
+  eleventyConfig.addPassthroughCopy("src/llms.txt");
   
   // Custom collection for glossary items
   eleventyConfig.addCollection("glossaryItems", function(collectionApi) {

--- a/src/llms.txt
+++ b/src/llms.txt
@@ -1,0 +1,632 @@
+# Spike Glossary
+
+> Spike's glossary is a 500+ term reference for incident management, on-call, and alerting terminology, built for the wider incident response community rather than just Spike users.
+
+Each entry defines a single term in one or two sentences: what it means, and where it fits in an incident's lifecycle or an on-call team's workflow. It's written for engineers, SREs, and incident managers who hit an unfamiliar term in a postmortem, runbook, or vendor doc and want a fast, precise definition, not a marketing page.
+
+## A
+
+- Acknowledge: https://spike.sh/glossary/acknowledge/ — Acknowledge is the act of confirming receipt of an incident alert and taking initial ownership of the response.
+- Acknowledgement Time: https://spike.sh/glossary/acknowledge-time/ — Acknowledgement Time is the duration between when an incident alert is triggered and when a responder confirms receipt of the alert.
+- Actionable Alert: https://spike.sh/glossary/actionable-alert/ — An actionable alert is a notification that provides clear, specific information about an incident that requires immediate attention and includes enough context for responders to take appropriate action.
+- Adaptive Response Systems: https://spike.sh/glossary/adaptive-response-systems/ — Adaptive Response Systems are intelligent incident management frameworks that learn from past incidents and automatically adjust their response strategies based on changing conditions and outcomes.
+- Affected Service: https://spike.sh/glossary/affected-service/ — An Affected Service is any system, application, infrastructure component, or business function that experiences degraded performance or complete failure during an incident.
+- After-Action Review: https://spike.sh/glossary/after-action-review/ — An After-Action Review (AAR) is a structured analysis conducted after an incident to identify what happened, why it happened, and how to improve future responses.
+- AI Incident Prediction: https://spike.sh/glossary/ai-incident-prediction/ — AI Incident Prediction uses machine learning algorithms to forecast potential incidents before they occur by analyzing patterns in system metrics, user behavior, and historical data.
+- AI Triage: https://spike.sh/glossary/ai-triage/ — AI Triage is the use of artificial intelligence to automatically assess and categorize incoming incidents based on their description, affected systems, and potential impact.
+- AI-Assisted Incident Response: https://spike.sh/glossary/ai-assisted-incident-response/ — AI-Assisted Incident Response uses artificial intelligence to support human responders during incident management.
+- AI-Driven Root Cause Analysis: https://spike.sh/glossary/ai-driven-root-cause-analysis/ — AI-Driven Root Cause Analysis uses machine learning algorithms to identify the underlying causes of incidents by analyzing system logs, metrics, events, and historical incident data.
+- AIOps: https://spike.sh/glossary/aiops/ — AIOps (Artificial Intelligence for IT Operations) is a technology approach that combines machine learning, big data analytics, and automation to improve incident management processes.
+- Alert: https://spike.sh/glossary/alert/ — An Alert is a notification triggered when a monitored system, application, or service exceeds predefined thresholds or exhibits abnormal behavior.
+- Alert Aggregation: https://spike.sh/glossary/alert-aggregation/ — Alert Aggregation is the process of combining multiple related alerts into a single notification or incident.
+- Alert Correlation: https://spike.sh/glossary/alert-correlation/ — Alert Correlation is the process of identifying relationships between different alerts to determine their common cause or connection.
+- Alert Deduplication: https://spike.sh/glossary/alert-deduplication/ — Alert Deduplication is the process of identifying and removing duplicate alerts for the same issue.
+- Alert Enrichment: https://spike.sh/glossary/alert-enrichment/ — Alert Enrichment is the process of automatically adding relevant context and information to alerts before they reach responders.
+- Alert Escalation: https://spike.sh/glossary/alert-escalation/ — Alert escalation is the process of moving an unresolved incident to higher-level responders.
+- Alert Fatigue: https://spike.sh/glossary/alert-fatigue/ — Alert fatigue is a condition where incident responders become desensitized to notifications due to receiving too many alerts, particularly false positives.
+- Alert Filtering: https://spike.sh/glossary/alert-filtering/ — Alert filtering is a process that screens incoming alerts based on predefined criteria to reduce noise and highlight significant notifications.
+- Alert Grouping: https://spike.sh/glossary/alert-grouping/ — Alert grouping is the process of combining related alerts into a single notification or case.
+- Alert Management Dashboard: https://spike.sh/glossary/alert-management-dashboard/ — An alert management dashboard is a centralized visual interface that displays real-time information about active alerts, their status, priority levels, and assigned responders.
+- Alert Noise: https://spike.sh/glossary/alert-noise/ — Alert noise refers to the excessive, often irrelevant notifications generated by monitoring systems that don't require immediate action.
+- Alert Prioritization: https://spike.sh/glossary/alert-prioritization/ — Alert prioritization is the process of assigning importance levels to incoming alerts based on business impact, urgency, and severity.
+- Alert Routing: https://spike.sh/glossary/alert-routing/ — Alert routing is the process of directing incident notifications to the appropriate individuals or teams based on factors like incident type, severity, affected systems, and team expertise.
+- Alert Suppression: https://spike.sh/glossary/alert-suppression/ — Alert suppression is the temporary or conditional blocking of specific alerts to prevent notification fatigue during known issues, maintenance periods, or non-actionable events.
+- Alert Threshold: https://spike.sh/glossary/alert-threshold/ — An alert threshold is a predefined value or condition that, when crossed, triggers an incident notification.
+- Alert Volume: https://spike.sh/glossary/alert-volume/ — Alert volume is the total number of alerts generated by monitoring or incident management systems over a specific period.
+- Algorithmic Alert Correlation: https://spike.sh/glossary/algorithmic-alert-correlation/ — Algorithmic Alert Correlation is a technique that uses mathematical algorithms to identify relationships between multiple alerts, grouping related alerts together to reduce noise and highlight the underlying issue.
+- Algorithmic Incident Classification: https://spike.sh/glossary/algorithmic-incident-classification/ — Algorithmic Incident Classification uses machine learning algorithms to automatically categorize incidents based on their characteristics, severity, and potential impact.
+- Andon Cord: https://spike.sh/glossary/andon-cord/ — An Andon Cord is a concept from lean manufacturing adapted for incident management, representing a mechanism that allows any team member to halt operations when they detect a critical issue.
+- Anomaly: https://spike.sh/glossary/anomaly/ — An anomaly in incident management is an unexpected deviation from normal system behavior that may indicate a problem.
+- Anomaly Detection: https://spike.sh/glossary/anomaly-detection/ — Anomaly detection in incident management is the automated process of identifying unusual patterns or behaviors that deviate from expected system performance.
+- Anomaly-Based Detection: https://spike.sh/glossary/anamoly-based-detection/ — Anomaly-Based Detection is a monitoring approach that identifies unusual patterns or behaviors in systems that deviate from established baselines.
+- Anticipatory Incident Management: https://spike.sh/glossary/anticipatory-incident-management/ — Anticipatory Incident Management is a forward-looking approach that uses predictive analytics, historical patterns, and contextual awareness to identify and address potential incidents before they occur.
+- Asset: https://spike.sh/glossary/asset/ — In incident management, an asset is any component of an organization's IT infrastructure that needs to be monitored, maintained, and protected.
+- Asset Management: https://spike.sh/glossary/asset-management/ — Asset management is the systematic process of deploying, operating, maintaining, and disposing of the resources that support incident response.
+- Assigned Incident: https://spike.sh/glossary/assigned-incident/ — An assigned incident is an issue that has been formally allocated to a specific individual or team for investigation and resolution.
+- Asynchronous Communication: https://spike.sh/glossary/asynchronous-communication/ — Asynchronous communication in incident management refers to the exchange of information that doesn't require immediate responses from all participants.
+- Attack Surface: https://spike.sh/glossary/attack-surface/ — Attack surface in incident management refers to the total sum of points where unauthorized users could potentially access systems or data.
+- Attack Vector: https://spike.sh/glossary/attack-vector/ — An attack vector is a specific path or method that an attacker uses to gain unauthorized access to a system, network, or application during a security incident.
+- Audit: https://spike.sh/glossary/audit/ — An audit in incident management is a systematic review of incident records, response procedures, and resolution processes to verify compliance with established protocols and identify areas for improvement.
+- Audit Log: https://spike.sh/glossary/audit-log/ — An audit log in incident management is a chronological record of all actions taken during an incident, including who performed each action, what was done, and when it occurred.
+- Audit Trail: https://spike.sh/glossary/audit-trail/ — An audit trail in incident management is a secure, comprehensive record that documents the sequence of activities from incident detection through resolution, creating an unalterable history of all actions and decisions.
+- Automated Escalation: https://spike.sh/glossary/automated-escalation/ — Automated escalation is a process that automatically routes alerts to additional or higher-level responders when certain conditions are met, such as time thresholds or severity levels.
+- Automated Incident Creation: https://spike.sh/glossary/automated-incident-creation/ — Automated Incident Creation is a process that automatically generates incident tickets or records when monitoring systems detect an issue or anomaly.
+- Automated Incident Routing: https://spike.sh/glossary/automated-incident-routing/ — Automated Incident Routing is the process of automatically assigning incidents to the appropriate teams or individuals based on predefined rules and criteria.
+- Automated Notification: https://spike.sh/glossary/automated-notification/ — Automated Notification is a system that sends alerts to relevant stakeholders when incidents occur or change status.
+- Automated Remediation: https://spike.sh/glossary/automated-remediation/ — Automated remediation is the process of using technology to automatically fix issues without human intervention when incidents occur.
+- Automated Response: https://spike.sh/glossary/automated-response/ — Automated response in incident management is a system-driven reaction to detected incidents based on predefined rules and workflows.
+- Automated Severity Assignment: https://spike.sh/glossary/automated-severity-assignment/ — Automated Severity Assignment is a process that automatically categorizes incidents by their impact and urgency using predefined criteria.
+- Automated Status Updates: https://spike.sh/glossary/automated-status-updates/ — Automated Status Updates are system-generated communications that inform stakeholders about incident progress without manual intervention.
+- Automated Triage: https://spike.sh/glossary/automated-triage/ — Automated Triage is a process that uses predefined rules and algorithms to automatically assess, categorize, and prioritize incoming incidents without human intervention.
+- Automated Triage Workflow: https://spike.sh/glossary/automated-triage-workflow/ — Automated Triage Workflow is a systematic process that uses predefined rules and algorithms to automatically categorize, prioritize, and route incidents to the appropriate teams or individuals without manual intervention.
+- Automation: https://spike.sh/glossary/automation/ — Automation in incident management is the use of technology to perform repetitive tasks without human intervention, including alert generation, ticket creation, initial diagnostics, and routine remediation actions.
+- Autonomous Incident Resolution: https://spike.sh/glossary/autonomous-incident-resolution/ — Autonomous Incident Resolution is an advanced incident management approach where systems automatically detect, diagnose, and resolve incidents without human intervention.
+- Autonomous Remediation: https://spike.sh/glossary/autonomous-remediation/ — Autonomous Remediation is the automated execution of corrective actions to resolve incidents or problems in IT systems without human intervention.
+
+## B
+
+- Backup: https://spike.sh/glossary/backup/ — A Backup in incident management refers to both data backup systems and backup personnel.
+- Backup Responder: https://spike.sh/glossary/backup-responder/ — A Backup Responder is a designated individual who steps in when the primary on-call responder is unavailable during an incident.
+- Baseline: https://spike.sh/glossary/baseline/ — A baseline is a documented, normal state of system performance, security, or operations that serves as a reference point for comparison.
+- Behavioral Analytics: https://spike.sh/glossary/behavioral-analytics/ — Behavioral Analytics in incident management is the process of analyzing patterns in system behavior to identify anomalies that may indicate incidents before they cause significant impact.
+- Bi-directional Integration: https://spike.sh/glossary/bi-directional-integration/ — Bi-directional Integration in incident management allows systems to both send and receive data between platforms.
+- Blackout Period: https://spike.sh/glossary/blackout-period/ — A Blackout Period is a predetermined timeframe during which system changes, updates, or maintenance activities are prohibited.
+- Blameless Culture: https://spike.sh/glossary/blameless-culture/ — A blameless culture in incident management is an approach that focuses on learning from failures without assigning fault to individuals.
+- Blameless Postmortem: https://spike.sh/glossary/blameless-postmortem/ — A blameless postmortem is a collaborative analysis of an incident that focuses on identifying systemic issues and opportunities for improvement without assigning blame to individuals.
+- Blockchain Incident Monitoring: https://spike.sh/glossary/blockchain-incident-monitoring/ — Blockchain Incident Monitoring is the practice of tracking and responding to security events, performance issues, and anomalies in blockchain networks and applications.
+- Bot-Assisted Triage: https://spike.sh/glossary/bot-assisted-triage/ — Bot-assisted triage is an incident management approach that uses automated bots to perform initial assessment and categorization of incoming incidents.
+- Bottleneck: https://spike.sh/glossary/bottleneck/ — A Bottleneck in incident management is a point in the response process that limits overall efficiency and extends resolution time.
+- Breach: https://spike.sh/glossary/breach/ — A breach is an incident where unauthorized access to systems, networks, or data occurs, potentially compromising confidentiality, integrity, or availability of information.
+- Break-Fix: https://spike.sh/glossary/break-fix/ — Break-fix is a reactive approach to incident management where problems are addressed only after they cause a failure or disruption.
+- Bridge Automation: https://spike.sh/glossary/bridge-automation/ — Bridge Automation refers to the technology that automatically creates and manages communication channels (like conference calls or chat rooms) when incidents occur.
+- Bridge Call: https://spike.sh/glossary/bridge-call/ — A Bridge Call is a conference call that brings together incident responders and stakeholders during an active incident.
+- Broadcast Notifications: https://spike.sh/glossary/broadcast-notifications/ — Broadcast Notifications are emergency communications sent simultaneously to multiple recipients across various channels during critical incidents.
+- Bug: https://spike.sh/glossary/bug/ — In incident management, a bug is a flaw or error in software or hardware that causes a system to produce unexpected or incorrect results.
+- Bulk Alert Management: https://spike.sh/glossary/bulk-alert-management/ — Bulk Alert Management is a capability that allows incident teams to handle multiple related alerts simultaneously.
+- Burnout: https://spike.sh/glossary/burnout/ — Burnout in incident management is a state of chronic physical and emotional exhaustion experienced by responders due to prolonged stress, frequent high-pressure incidents, and interrupted work-life balance.
+- Burnout Prevention Algorithms: https://spike.sh/glossary/burnout-prevention-algorithms/ — Burnout prevention algorithms are computational systems that analyze on-call workloads, incident response patterns, and team metrics to identify potential responder burnout before it occurs.
+- Business Continuity: https://spike.sh/glossary/business-continuity/ — Business Continuity is the capability of an organization to maintain essential functions during and after a disaster or major incident.
+- Business Continuity Plan (BCP): https://spike.sh/glossary/business-continuity-plan-bcp/ — A Business Continuity Plan (BCP) is a documented strategy that outlines how an organization will continue operating during unplanned disruptions in service.
+- Business Impact Analysis (BIA): https://spike.sh/glossary/business-impact-analysis-bia/ — Business Impact Analysis is a systematic process that identifies and evaluates the potential effects of an interruption to critical business operations.
+- Business Impact Dashboard: https://spike.sh/glossary/business-impact-dashboard/ — A Business Impact Dashboard is a visual display that shows how incidents affect business metrics and customer experience in real-time.
+- Business Service: https://spike.sh/glossary/business-service/ — A business service is a set of related functions that support core business activities.
+- Business Service Intelligence: https://spike.sh/glossary/business-service-intelligence/ — Business service intelligence is the practice of mapping incidents to business services and analyzing their impact on organizational objectives.
+- Business Service Mapping: https://spike.sh/glossary/business-service-mapping/ — Business Service Mapping is the process of documenting relationships between IT components and the business services they support.
+
+## C
+
+- Categorization: https://spike.sh/glossary/categorization/ — Categorization in incident management is the process of classifying incidents based on their type, impact, urgency, or other relevant attributes.
+- Centralized Incident Dashboard: https://spike.sh/glossary/centralized-dashboard/ — A Centralized Incident Dashboard is a unified visual interface that displays real-time information about all ongoing incidents across an organization.
+- Chain Of Command: https://spike.sh/glossary/chain-of-command/ — Chain of Command in incident management is a hierarchical structure that defines reporting relationships and decision-making authority during incidents.
+- Change Management: https://spike.sh/glossary/change-management/ — Change Management is a structured approach to implementing and tracking modifications to IT systems, infrastructure, or processes.
+- Chaos Engineering: https://spike.sh/glossary/chaos-engineering/ — Chaos Engineering is the practice of deliberately introducing controlled failures into a system to test its resilience and identify weaknesses before they cause real incidents.
+- Cloud Native Incident Management: https://spike.sh/glossary/cloud-native-incident-management/ — Cloud Native Incident Management is an approach to handling incidents specifically designed for containerized, microservice-based applications running in cloud environments.
+- Cognitive Incident Analysis: https://spike.sh/glossary/cognitive-incident-analysis/ — Cognitive Incident Analysis is an advanced approach to understanding incidents that examines the mental processes, decision-making patterns, and cognitive factors that influenced how teams responded to problems.
+- Collaborative Incident Response: https://spike.sh/glossary/collaborative-incident-response/ — Collaborative Incident Response is an approach where multiple teams work together to resolve incidents using shared tools, communication channels, and processes.
+- Collaborative Resolution: https://spike.sh/glossary/collaborative-resolution/ — Collaborative resolution is an incident management approach where cross-functional teams work together to solve complex incidents.
+- Command and Control: https://spike.sh/glossary/command-and-control/ — Command and Control is a structured management approach used in incident response that establishes clear leadership roles and decision-making authority.
+- Command Center: https://spike.sh/glossary/command-center/ — A command center is a centralized hub for monitoring, managing, and coordinating responses to incidents across an organization.
+- Command Post: https://spike.sh/glossary/command-post/ — A Command Post is a designated physical or virtual location where incident response leaders gather during major incidents to coordinate activities, make decisions, and communicate with stakeholders.
+- Compliance: https://spike.sh/glossary/compliance/ — Compliance in incident management refers to adhering to regulatory requirements, industry standards, and internal policies when handling and resolving incidents.
+- Computer Security Incident Response Team (CSIRT): https://spike.sh/glossary/computer-security-incident-reponse-team-csirt/ — A Computer Security Incident Response Team (CSIRT) is a specialized group responsible for receiving, analyzing, and responding to computer security incidents.
+- Configurable Workflows: https://spike.sh/glossary/configurable-workflows/ — Configurable workflows are customizable, automated processes that guide incident response teams through predefined steps.
+- Configuration Item (CI): https://spike.sh/glossary/configuration-item-ci/ — A Configuration Item (CI) is any component that needs to be managed to deliver an IT service.
+- Containerized Recovery: https://spike.sh/glossary/containerized-recovery/ — Containerized Recovery is an incident management approach that uses container technology to quickly restore services after an incident.
+- Containment: https://spike.sh/glossary/containment/ — Containment is the process of limiting the scope and impact of an active incident to prevent it from spreading or causing additional damage.
+- Context Enrichment: https://spike.sh/glossary/context-enrichment/ — Context enrichment is the process of adding relevant information to incident alerts, providing responders with a more comprehensive understanding of the issue.
+- Contextual Intelligence: https://spike.sh/glossary/contextual-intelligence/ — Contextual Intelligence in incident management is the ability to automatically gather and present relevant information about an incident based on its specific characteristics.
+- Continuous Monitoring: https://spike.sh/glossary/continuous-monitoring/ — Continuous Monitoring is the ongoing surveillance of IT systems, networks, and applications to detect incidents, anomalies, or security breaches in real-time.
+- Continuous Resilience: https://spike.sh/glossary/continuous-resilience/ — Continuous Resilience is an approach to incident management that focuses on constantly improving an organization's ability to withstand, adapt to, and recover from disruptions.
+- Correlation: https://spike.sh/glossary/correlation/ — Correlation in incident management is the process of identifying relationships between multiple alerts, events, or incidents to determine if they share a common cause or are related in some way.
+- Correlation Rules: https://spike.sh/glossary/correlation-rules/ — Correlation rules are predefined logic sets that help identify relationships between multiple events or alerts.
+- Crisis Management: https://spike.sh/glossary/crisis-management/ — Crisis Management is a systematic approach to handling unexpected, disruptive events that threaten to harm an organization, its stakeholders, or the public.
+- Critical Incident: https://spike.sh/glossary/critical-incident/ — A Critical Incident is a high-severity event that significantly impacts business operations, customer experience, or data security.
+- Critical Service: https://spike.sh/glossary/critical-service/ — A critical service is any system or application essential for business operations. If it fails, it causes major disruption or financial loss.
+- Cross-Platform Automation: https://spike.sh/glossary/cross-platform-automation/ — Cross-platform Automation in incident management refers to using tools and workflows that operate across different systems, applications, and environments to automate incident detection, notification, and resolution processes.
+- Cross-site Scripting (XSS): https://spike.sh/glossary/xss-cross-site-scripting/ — XSS attacks let hackers inject code into websites that runs in users' browsers to steal data or take control.
+- Cross-team Coordination: https://spike.sh/glossary/cross-team-coordination/ — Cross-team coordination in incident management involves orchestrating efforts between different functional groups to resolve incidents efficiently.
+- Custom Incident Fields: https://spike.sh/glossary/custom-incident-fields/ — Custom incident fields are configurable data points that organizations add to their incident management system to capture information specific to their needs.
+- Customer Experience Monitoring: https://spike.sh/glossary/customer-experience-monitoring/ — Customer Experience Monitoring in incident management tracks how system issues affect users.
+- Customer Impact: https://spike.sh/glossary/customer-impact/ — Customer impact in incident management refers to the effect an incident has on users or clients of a service.
+- Customer Notification System: https://spike.sh/glossary/customer-notification-system/ — A customer notification system is a tool that automatically informs customers about incidents or outages affecting services they use.
+- Cyber Physical Systems Incidents: https://spike.sh/glossary/cyber-physical-systems-incidents/ — Cyber Physical Systems Incidents are events that affect systems where digital and physical components interact. These incidents can impact both digital operations and physical infrastructure, potentially causing real-world consequences.
+
+## D
+
+- Dashboard: https://spike.sh/glossary/dashboard/ — A dashboard is a visual display that presents critical incident management data in real-time.
+- Dashboard Customization: https://spike.sh/glossary/dashboard-customization/ — Dashboard customization is the process of tailoring incident management displays to show relevant metrics, alerts, and statuses based on specific team needs and roles.
+- Data Breach: https://spike.sh/glossary/data-breach/ — A data breach is an incident where unauthorized parties gain access to sensitive, protected, or confidential information.
+- Data Loss Prevention (DLP): https://spike.sh/glossary/data-loss-prevention-dlp/ — Data Loss Prevention is a strategy and set of tools designed to detect and prevent unauthorized transmission, access, or use of sensitive information.
+- Data-Driven Incident Response: https://spike.sh/glossary/data-driven-incident-response/ — Data-driven incident response is an approach that uses historical and real-time data to guide incident management decisions.
+- Decentralized Monitoring Systems: https://spike.sh/glossary/decentralized-monitoring-systems/ — Decentralized Monitoring Systems distribute monitoring responsibilities across multiple nodes or teams rather than relying on a single central monitoring solution.
+- Deduplication: https://spike.sh/glossary/deduplication/ — Deduplication in incident management is the process of identifying and combining duplicate alerts or incidents to reduce noise and prevent multiple teams from working on the same issue.
+- Deduplication Rules: https://spike.sh/glossary/deduplication-rules/ — Deduplication rules are configurations that automatically identify and combine duplicate or related alerts into a single incident.
+- Dependency Mapping: https://spike.sh/glossary/dependency-mapping/ — Dependency mapping is the process of identifying and documenting relationships between IT services, applications, and infrastructure components.
+- Detection Time (MTTD): https://spike.sh/glossary/detection-time-mttd/ — Detection Time, often measured as Mean Time to Detect (MTTD), is the average time between when an incident occurs and when it is discovered by the organization.
+- Diagnosis: https://spike.sh/glossary/diagnosis/ — Diagnosis is the process of investigating and identifying the root cause of an incident.
+- Disaster Recovery (DR): https://spike.sh/glossary/disaster-recovery-dr/ — Disaster Recovery (DR) is a set of policies, tools, and procedures designed to help an organization recover IT systems and infrastructure after a major disruption or disaster.
+- Disaster Recovery Plan (DRP): https://spike.sh/glossary/disaster-recovery-plan-drp/ — A Disaster Recovery Plan (DRP) is a documented, structured approach that describes how an organization will recover and restore critical IT infrastructure and systems following a disaster.
+- Distributed Incident Management: https://spike.sh/glossary/distributed-incident-management/ — Distributed Incident Management is an approach where incident response responsibilities are spread across multiple teams, locations, or time zones.
+- Downtime: https://spike.sh/glossary/downtime/ — Downtime refers to the period when a system, service, or infrastructure is unavailable or not functioning as intended.
+- Dynamic Alert Routing: https://spike.sh/glossary/dynamic-alert-routing/ — Dynamic alert routing is an incident management capability that automatically directs alerts to the most appropriate responders based on factors like alert type, severity, time of day, and team workload.
+- Dynamic Escalation Policies: https://spike.sh/glossary/dynamic-escalation-policies/ — Dynamic escalation policies are flexible, context-aware rules that determine how and when incidents escalate to additional responders or teams.
+- Dynamic Incident Prediction: https://spike.sh/glossary/dynamic-incident-prediction/ — Dynamic Incident Prediction uses machine learning and historical incident data to forecast potential future incidents before they occur.
+- Dynamic Thresholds: https://spike.sh/glossary/dynamic-thresholds/ — Dynamic thresholds are adaptive alert boundaries that automatically adjust based on historical patterns, time of day, or other contextual factors.
+
+## E
+
+- Edge Computing Incident Management: https://spike.sh/glossary/edge-computing-incident-management/ — Edge Computing Incident Management is a distributed approach to handling IT incidents that processes data near the source rather than relying on a centralized system.
+- Elastic Incident Response Teams: https://spike.sh/glossary/elastic-incident-response-teams/ — Elastic Incident Response Teams are flexible groups that expand or contract based on incident severity and needs.
+- Emergency Change: https://spike.sh/glossary/emergency-change/ — An Emergency Change is an urgent modification to IT systems or infrastructure that must be implemented immediately to resolve a critical incident or prevent significant business impact.
+- Emergency Change Advisory Board (ECAB): https://spike.sh/glossary/emergency-change-advisory-board-ecab/ — An Emergency Change Advisory Board (ECAB) is a smaller, more accessible version of the standard Change Advisory Board that convenes quickly to assess and approve emergency changes.
+- Emergency Committee: https://spike.sh/glossary/emergency-committee/ — An Emergency Committee is a cross-functional team responsible for managing organizational response during major incidents or crises.
+- Emergency Plan: https://spike.sh/glossary/emergency-plan/ — An Emergency Plan is a documented set of procedures designed to guide an organization's response to critical incidents or disasters.
+- Enhanced Monitoring With AI/ML: https://spike.sh/glossary/enhanced-monitoring-with-ai-ml/ — Enhanced Monitoring with AI/ML uses artificial intelligence and machine learning algorithms to improve incident detection by analyzing patterns in system behavior.
+- Enterprise AIOps Solutions: https://spike.sh/glossary/enterprise-aiops-solutions/ — Enterprise AIOps Solutions are comprehensive platforms that apply artificial intelligence to IT operations across an organization.
+- Enterprise Architect: https://spike.sh/glossary/enterprise-architect/ — An Enterprise Architect is a strategic role responsible for designing and overseeing an organization's IT architecture to align with business goals. In incident management, they provide critical insights into system dependencies, potential impacts, and architectural solutions to prevent recurring incidents.
+- Enterprise Architecture (EA): https://spike.sh/glossary/enterprise-architecture-ea/ — Enterprise Architecture (EA) is a strategic framework that aligns an organization's IT infrastructure with its business goals and processes.
+- Enterprise Policies And Regulations: https://spike.sh/glossary/enterprise-policies-and-regulations/ — Enterprise Policies and Regulations are formal guidelines and rules that govern how an organization handles incidents, including reporting requirements, response procedures, and compliance obligations.
+- Error Budget: https://spike.sh/glossary/error-budget/ — An error budget is a predefined amount of acceptable system downtime or errors within a specific period.
+- Escalate: https://spike.sh/glossary/escalate/ — Escalate means transferring an incident to a team or individual with more expertise, authority, or resources.
+- Escalation Delay: https://spike.sh/glossary/escalation-delay/ — Escalation delay is the time taken between an incident being detected and the moment it is escalated to the next level of response.
+- Escalation Matrix: https://spike.sh/glossary/escalation-matrix/ — An escalation matrix is a visual representation of the escalation policy, showing who to contact at each level of escalation for different types of incidents.
+- Escalation Policy: https://spike.sh/glossary/escalation-policy/ — An escalation policy is a predefined set of rules that determine how and when to elevate an incident to higher levels of support or management.
+- Escalation Workflow: https://spike.sh/glossary/escalation-workflow/ — An escalation workflow is a predefined sequence of steps that determines how and when an incident is routed to different team members or teams based on factors like severity, time elapsed, or special requirements.
+- Event: https://spike.sh/glossary/event/ — An event is any observable occurrence in an IT system or business process that may require attention.
+- Event Categorization Scheme: https://spike.sh/glossary/event-categorization-scheme/ — An Event Categorization Scheme is a structured system for classifying and organizing events based on characteristics like source, severity, type, and impact.
+- Event Correlation: https://spike.sh/glossary/event-correlation/ — Event Correlation is the process of analyzing relationships between multiple events to identify patterns, causes, and effects.
+- Event Deduplication: https://spike.sh/glossary/event-deduplication/ — Event deduplication is the process of identifying and eliminating duplicate incident alerts or events to prevent alert fatigue.
+- Event Enrichment: https://spike.sh/glossary/event-enrichment/ — Event enrichment is the process of adding context and relevant information to raw event data.
+- Event Filtering: https://spike.sh/glossary/event-filtering/ — Event filtering is a process in incident management that selects or excludes specific events based on predefined criteria.
+- Event Management: https://spike.sh/glossary/event-management/ — Event management is the process of identifying, analyzing, and addressing events that could impact IT services or business operations.
+- Event Monitoring: https://spike.sh/glossary/event-monitoring/ — Event monitoring is the continuous observation of IT systems and applications to detect and log events that may affect performance, availability, or security.
+- Event Record: https://spike.sh/glossary/event-record/ — An event record is a documented account of a significant occurrence within an IT environment.
+- Event Review: https://spike.sh/glossary/event-review/ — Event review is the process of analyzing recorded events to gain insights, identify patterns, and improve incident management processes.
+- Event Routing: https://spike.sh/glossary/event-routing/ — Event routing is the process of directing incident alerts to the appropriate teams or individuals based on predefined rules and criteria.
+- Event Suppression: https://spike.sh/glossary/event-suppression/ — Event suppression is the temporary blocking of alerts from specific systems or services during planned maintenance, testing, or known outages.
+- Event Trends And Patterns: https://spike.sh/glossary/event-trends-and-patterns/ — Event trends and patterns in incident management refer to recurring or notable characteristics observed in system events over time.
+- Event-Driven Automation: https://spike.sh/glossary/event-driven-automation/ — Event-Driven Automation is an approach to incident management where system events automatically trigger predefined response actions without human intervention.
+- External Status Page: https://spike.sh/glossary/external-status-page/ — An external status page is a public-facing webpage that communicates the operational status of an organization's services to customers, users, and other stakeholders.
+
+## F
+
+- Failure Mode And Effects Analysis (FMEA): https://spike.sh/glossary/failure-mode-and-effects-analysis-fmea/ — Failure Mode and Effects Analysis (FMEA) is a systematic approach to identify potential failures in systems, processes, or services before they occur.
+- Failure Point: https://spike.sh/glossary/failure-point/ — A failure point is a specific component, process, or connection in a system that can malfunction and cause an incident.
+- False Alarm: https://spike.sh/glossary/false-alarm/ — A false alarm in incident management is an alert triggered by something other than a real incident or threat.
+- Fault Injection Testing (Chaos Engineering): https://spike.sh/glossary/fault-injection-testing-chaos-engineering/ — Fault injection testing, also known as chaos engineering, is a disciplined approach to improving system resilience by deliberately introducing failures in controlled environments.
+- Fault Isolation Dashboard: https://spike.sh/glossary/fault-isolation-dashboard/ — A Fault Isolation Dashboard is a visual interface that helps incident responders quickly identify and isolate the source of failures within complex systems.
+- Fault Prediction with AI/ML: https://spike.sh/glossary/fault-prediction-with-ai-ml/ — Fault prediction with AI/ML is a proactive approach to incident management that uses artificial intelligence and machine learning algorithms to analyze patterns in system data and predict potential failures before they occur.
+- Fault Tolerance: https://spike.sh/glossary/fault-tolerance/ — Fault tolerance is a system's ability to continue functioning properly when one or more of its components fail.
+- Fault Tree Analysis: https://spike.sh/glossary/fault-tree-analysis/ — Fault Tree Analysis (FTA) is a systematic method for identifying potential causes of system failures.
+- Federated Incident Management Systems: https://spike.sh/glossary/federated-incident-management-systems/ — Federated Incident Management Systems connect multiple incident management platforms across different teams, departments, or organizations to create a unified view of incidents while maintaining local control.
+- Feedback Loop: https://spike.sh/glossary/feedback-loop/ — A feedback loop in incident management is a process where information about past incidents is collected, analyzed, and used to improve future incident response.
+- First Responder: https://spike.sh/glossary/first-responder/ — A first responder in incident management is the person or team who reacts first to an alert or incident.
+- First Responder Assignment: https://spike.sh/glossary/first-responder-assignment/ — First Responder Assignment is the process of designating specific team members to be the initial point of contact when an incident occurs.
+- First-Line Support: https://spike.sh/glossary/first-line-support/ — First-line support is the initial point of contact for incident reporting and resolution.
+- Fix: https://spike.sh/glossary/fix/ — A fix is a solution or correction implemented to resolve an incident or problem.
+- Fixed Asset: https://spike.sh/glossary/fixed-asset/ — In incident management, a fixed asset refers to long-term physical infrastructure components like servers, network equipment, or data centers that support IT operations.
+- Flexible Escalation Policy: https://spike.sh/glossary/flexible-escalation-policy/ — A flexible escalation policy is an adaptable framework that determines how and when incidents are escalated to different team members based on factors like severity, time of day, and available resources.
+- Flexible Workflows For Distributed Teams: https://spike.sh/glossary/flexible-workflows-for-distributed-teams/ — Flexible workflows for distributed teams are customizable incident management processes designed to accommodate teams working across different locations, time zones, and work arrangements.
+- Follow-the-Sun Schedule: https://spike.sh/glossary/follow-the-sun-schedule/ — Follow-the-Sun Schedule is an oncall management approach where responsibility for handling incidents transfers between teams in different time zones, creating 24/7 coverage without requiring night shifts.
+- Follow-Up Notification: https://spike.sh/glossary/follow-up-notification/ — A follow-up notification is a communication sent after an initial incident alert to provide updates on status, resolution progress, or additional information to stakeholders.
+
+## G
+
+- Gamification Of Incident Training: https://spike.sh/glossary/gamification-of-incident-training/ — Gamification of Incident Training is the application of game-design elements and principles to incident management training programs.
+- Gap Analysis: https://spike.sh/glossary/gap-analysis/ — Gap Analysis in incident management is a systematic process that compares current incident response capabilities against desired or required standards.
+- Generative AI for Incident Response: https://spike.sh/glossary/generative-ai-for-incident-response/ — Generative AI for Incident Response is the application of artificial intelligence technologies that can create, or generate, new content to assist in managing and resolving incidents.
+- Geo-Aware Incident Management: https://spike.sh/glossary/geo-aware-incident-management/ — Geo-aware Incident Management is an approach that takes into account the geographical location and context of incidents when managing and responding to them.
+- Geo-distributed Alert Routing: https://spike.sh/glossary/geo-distributed-alert-routing/ — Geo-distributed Alert Routing is a system that directs incident alerts to appropriate responders based on geographic location.
+- Global Incident Intelligence Sharing: https://spike.sh/glossary/global-incident-intelligence-sharing/ — Global Incident Intelligence Sharing is a collaborative approach where organizations exchange information about security incidents, threats, and vulnerabilities across geographical boundaries.
+- Global Incident Response Team: https://spike.sh/glossary/global-incident-response-team/ — A Global Incident Response Team is a distributed group of specialists who manage incidents across different geographic regions and time zones.
+- Global Status Dashboard: https://spike.sh/glossary/global-status-dashboard/ — A Global Status Dashboard is a centralized, real-time visualization tool that displays the operational status of an organization's systems, services, and infrastructure across multiple locations worldwide.
+- Gold-Silver-Bronze Command Structure: https://spike.sh/glossary/gold-silver-bronze-command-structure/ — The Gold-Silver-Bronze Command Structure is a hierarchical incident management framework used to organize response teams during major incidents.
+- Graph-Based Dependency Mapping: https://spike.sh/glossary/graph-based-dependency-mapping/ — Graph-based Dependency Mapping is a visualization technique that uses graph theory to represent relationships between IT systems, services, and infrastructure components.
+- Ground Support Unit: https://spike.sh/glossary/ground-support-unit/ — A Ground Support Unit is a specialized team that provides logistical and operational support during major incidents.
+- Group Notifications: https://spike.sh/glossary/group-notifications/ — Group Notifications are alert messages sent simultaneously to multiple team members during an incident.
+- Guided Remediation: https://spike.sh/glossary/guided-remediation/ — Guided Remediation is a structured approach to incident resolution that provides responders with step-by-step instructions for addressing specific types of incidents.
+- Guided Response: https://spike.sh/glossary/guided-response/ — Guided Response is a structured approach to incident management that provides step-by-step instructions for responders to follow during specific types of incidents.
+
+## H
+
+- Handover: https://spike.sh/glossary/handover/ — Handover is the formal process of transferring responsibility for an ongoing incident from one person or team to another.
+- Hazard Identification: https://spike.sh/glossary/hazard-identification/ — Hazard identification is the process of recognizing and documenting conditions, activities, or situations that could potentially cause incidents or service disruptions.
+- Hazard Mitigation: https://spike.sh/glossary/hazard-mitigation/ — Hazard mitigation in incident management is the process of identifying potential risks and taking proactive steps to reduce their impact or likelihood.
+- Health Check: https://spike.sh/glossary/health-check/ — A health check in incident management is a routine assessment of a system's operational status.
+- Health Monitoring Dashboards: https://spike.sh/glossary/health-monitoring-dashboards/ — Health Monitoring Dashboards are visual interfaces that display real-time status information about critical systems, services, and infrastructure components.
+- High Availability: https://spike.sh/glossary/high-availability/ — High Availability is a system design approach that ensure an agreed level of operational performance, usually uptime, for a higher than normal period.
+- High Priority Incident: https://spike.sh/glossary/high-priority-incident/ — A High Priority Incident is an event that severely impacts business operations, affects numerous users, or threatens data security.
+- High-Severity Alert Routing: https://spike.sh/glossary/high-severity-alert-routing/ — High-Severity Alert Routing is a process that automatically directs critical alerts to the appropriate response teams based on predefined rules and severity levels.
+- Historical Data Analysis: https://spike.sh/glossary/historical-data-analysis/ — Historical data analysis in incident management involves examining past incident records to identify patterns, trends, and insights.
+- Historical Incident Reports: https://spike.sh/glossary/historical-incident-reports/ — Historical Incident Reports are comprehensive records of past incidents that document what happened, how teams responded, resolution steps taken, and lessons learned.
+- Hotfix: https://spike.sh/glossary/hotfix/ — A hotfix is an urgent software update applied directly to production systems to address critical bugs, security vulnerabilities, or functionality issues.
+- Human Error: https://spike.sh/glossary/human-error/ — Human error in incident management refers to mistakes, oversights, or poor decisions made by individuals that lead to or exacerbate incidents.
+- Human-in-the-Loop AI For Incident Response: https://spike.sh/glossary/human-in-the-loop-ai-for-incident-response/ — Human-in-the-Loop AI for Incident Response is an approach that combines artificial intelligence with human expertise to manage and resolve incidents.
+- Hybrid Cloud Incident Management: https://spike.sh/glossary/hybrid-cloud-incident-management/ — Hybrid cloud incident management involves detecting, responding to, and resolving issues across both on-premises and cloud-based infrastructure.
+- Hybrid Incident Escalation: https://spike.sh/glossary/hybrid-incident-escalation/ — Hybrid Incident Escalation is an approach that combines automated and manual escalation processes to route incidents to the appropriate responders.
+- Hyperautomation In Incident Management: https://spike.sh/glossary/hyperautomation-in-incident-management/ — Hyperautomation in Incident Management is the application of advanced technologies like AI, machine learning, and robotic process automation to automate complex incident management tasks.
+
+## I
+
+- Immediate Resolution: https://spike.sh/glossary/immediate-resolution/ — Immediate Resolution is the rapid fixing of an incident without escalation to other teams or extensive investigation.
+- Impact Analysis Tools For Incidents: https://spike.sh/glossary/impact-analysis-tools-for-incidents/ — Impact Analysis Tools for Incidents are software solutions that help organizations assess and visualize the potential consequences of IT incidents on business operations, services, and users.
+- Incident: https://spike.sh/glossary/incident/ — An incident is an unplanned interruption, degradation, or failure of a service, system, or infrastructure component that impacts business operations or users.
+- Incident Categorization: https://spike.sh/glossary/incident-categorization/ — Incident categorization is the process of classifying incidents based on their nature, impact, and urgency to facilitate proper handling and resolution.
+- Incident Closure: https://spike.sh/glossary/incident-closure/ — Incident closure is the final stage in the incident management lifecycle where an incident is formally marked as resolved after confirming the issue has been fixed and normal service has been restored.
+- Incident Command System (ICS): https://spike.sh/glossary/incident-command-system-ics/ — The Incident Command System (ICS) is a standardized approach to incident management that provides a hierarchical structure for command, control, and coordination during emergencies.
+- Incident Commander: https://spike.sh/glossary/incident-commander/ — An Incident Commander is the designated leader who manages the response to an incident.
+- Incident Detection: https://spike.sh/glossary/incident-detection/ — Incident detection is the process of identifying events or conditions that indicate a potential service disruption, security breach, or system failure.
+- Incident Escalation: https://spike.sh/glossary/incident-escalation/ — Incident escalation is the process of transferring an incident to higher levels of technical expertise or management authority when it cannot be resolved at the current level or requires additional attention due to its severity or impact.
+- Incident Identification: https://spike.sh/glossary/incident-identification/ — Incident identification is the process of recognizing events that disrupt normal operations and require a response.
+- Incident Lifecycle: https://spike.sh/glossary/incident-lifecycle/ — The incident lifecycle is the complete sequence of stages an incident goes through from initial detection to final resolution and review.
+- Incident Logging: https://spike.sh/glossary/incident-logging/ — Incident logging is the process of creating a formal record of an incident in an incident management system.
+- Incident Management: https://spike.sh/glossary/incident-management/ — Incident management is the process of responding to unplanned events or service disruptions to restore normal operations as quickly as possible.
+- Incident Manager: https://spike.sh/glossary/incident-manager/ — An Incident Manager is a professional responsible for overseeing the entire incident management process.
+- Incident Model: https://spike.sh/glossary/incident-model/ — An Incident Model is a standardized framework for categorizing and responding to different types of incidents.
+- Incident Monitoring: https://spike.sh/glossary/incident-monitoring/ — Incident Monitoring is the continuous observation of systems, networks, and applications to detect and track incidents.
+- Incident Prediction with AI/ML: https://spike.sh/glossary/incident-prediction-with-ai-ml/ — Incident Prediction with AI/ML uses artificial intelligence and machine learning algorithms to analyze historical incident data, identify patterns, and forecast potential future incidents in IT systems.
+- Incident Prioritization: https://spike.sh/glossary/incident-prioritization/ — Incident Prioritization is the process of assessing and ranking incidents based on their urgency and impact on business operations.
+- Incident Record: https://spike.sh/glossary/incident-record/ — An incident record is a documented entry that captures all the details of an incident from detection to resolution.
+- Incident Report: https://spike.sh/glossary/incident-report/ — An incident report is a formal document that summarizes an incident after it has been resolved.
+- Incident Resolution: https://spike.sh/glossary/incident-resolution/ — Incident resolution is the process of restoring normal service operation after an incident has occurred.
+- Incident Response: https://spike.sh/glossary/incident-response/ — Incident response is the organized approach to addressing and managing the aftermath of a security breach, service disruption, or other unexpected event.
+- Incident Status Information: https://spike.sh/glossary/incident-status-information/ — Incident Status Information is real-time data about the current state of an incident, including its severity, affected systems, resolution progress, and estimated time to resolution.
+- Incident Summary: https://spike.sh/glossary/incident-summary/ — An incident summary is a brief overview of an incident, including what happened, when it occurred, and its impact.
+- Initial Response: https://spike.sh/glossary/initial-response/ — Initial response is the first set of actions taken after an incident is detected.
+- Instant Notifications: https://spike.sh/glossary/instant-notifications/ — Instant Notifications are immediate alerts sent to incident responders through multiple channels when an incident is detected.
+- Integrated AIOps For Proactive Responses: https://spike.sh/glossary/integrated-aiops-for-proactive-responses/ — Integrated AIOps for Proactive Responses combines artificial intelligence for IT operations (AIOps) with existing IT systems to automate and improve incident detection, analysis, and response.
+- Integrated Status Pages: https://spike.sh/glossary/integrated-status-pages/ — Integrated Status Pages are centralized dashboards that display real-time information about the operational status of various services, applications, and infrastructure components.
+- Integration Ecosystem: https://spike.sh/glossary/integration-ecosystem/ — An integration ecosystem in incident management is a network of interconnected tools, platforms, and systems that work together to detect, respond to, and resolve incidents.
+- Intelligent Alert Routing: https://spike.sh/glossary/intelligent-alert-routing/ — Intelligent Alert Routing is an automated system that directs incident alerts to the most appropriate responder or team based on factors like incident type, severity, affected systems, time of day, and responder expertise or availability.
+- Intelligent Automation In Incident Management: https://spike.sh/glossary/intelligent-automation-in-incident-management/ — Intelligent Automation in Incident Management uses AI and machine learning to automate incident detection, classification, routing, and even resolution.
+- Interactive Postmortems: https://spike.sh/glossary/interactive-postmortems/ — Interactive Postmortems are collaborative incident review sessions where team members actively participate in analyzing what happened during an incident, why it occurred, and how to prevent similar issues.
+- Internal Status Page: https://spike.sh/glossary/internal-status-page/ — An Internal Status Page is a private dashboard that shows the operational status of an organization's internal systems, tools, and services.
+
+## J
+
+- Jeopardy Management: https://spike.sh/glossary/jeopardy-management/ — Jeopardy Management monitors tasks to predict delays and helps teams act to avoid missed deadlines.
+- Joint AI-human Response Teams: https://spike.sh/glossary/joint-ai-human-response-teams/ — AI and humans team up to tackle incidents together.
+- Joint Command: https://spike.sh/glossary/joint-command/ — Joint Command lets leaders from different agencies share decisions in managing incidents together.
+- Joint Incident View: https://spike.sh/glossary/joint-incident-view/ — A Joint Incident View shares real-time updates on incidents, including status, actions, and responders.
+- Joint Information Center (JIC): https://spike.sh/glossary/joint-information-center-jic/ — A JIC is where agencies work together to share accurate and timely info during incidents.
+- Journey Mapping For Incident Response: https://spike.sh/glossary/journey-mapping-for-incident-response/ — Journey maps track how everyone works through incidents from start to finish.
+- Judgment Call: https://spike.sh/glossary/judgement-call/ — A judgment call is a decision made using experience and intuition when rules don't clearly apply.
+- Jump Host Access: https://spike.sh/glossary/jump-host-access/ — A jump host is a secure gateway server that controls access to private networks and sensitive resources.
+- Just-in-time Alert Routing: https://spike.sh/glossary/just-in-time-alert-routing/ — Just-in-time Alert Routing notifies the right person or team based on context like schedules or incidents.
+- Just-in-time Knowledge Base: https://spike.sh/glossary/just-in-time-knowledge-base/ — A Just-in-time Knowledge Base gives responders the right info automatically when needed during incidents.
+
+## K
+
+- Key Performance Indicators (KPIs): https://spike.sh/glossary/key-performance-indicators-kpis/ — KPIs measure how well businesses handle incidents using metrics like response time and system reliability.
+- Key Risk Indicators (KRIs): https://spike.sh/glossary/key-risk-indicators/ — KRIs are metrics that warn when risks exceed acceptable levels, helping predict issues early.
+- Key Stakeholder Notifications: https://spike.sh/glossary/key-stakeholder-notifications/ — Key stakeholder notifications inform concerned people about incident status and impact internally or externally.
+- Knowledge Automation In Incident Resolution: https://spike.sh/glossary/knowledge-automation-in-incident-resolution/ — AI-powered automation resolves incidents by applying predefined knowledge without human intervention.
+- Knowledge Base: https://spike.sh/glossary/knowledge-base/ — A knowledge base is a central hub with guides, FAQs, and solutions for quick incident resolution.
+- Knowledge Graphs For Incident Correlation: https://spike.sh/glossary/knowledge-graphs-for-incident-correlation/ — Knowledge graphs connect IT entities (alerts, services, etc) to identify major incidents faster.
+- Knowledge Management: https://spike.sh/glossary/knowledge-management/ — Knowledge management captures and shares lessons from incidents to improve future responses.
+- Knowledge-Centered Postmortems: https://spike.sh/glossary/knowledge-centered-postmortems/ — Incident reviews that collect and structure knowledge to prevent and handle future problems.
+- Known Error: https://spike.sh/glossary/known-error/ — A Known Error is a documented IT issue with a root cause and workaround but no permanent fix yet.
+- Known Error Database (KEDB): https://spike.sh/glossary/known-error-database-kedb/ — Known Error Databases document errors, their symptoms, causes, and effective workarounds.
+
+## L
+
+- Latency: https://spike.sh/glossary/latency/ — Latency is the time delay between an action and the resulting response in a system.
+- Latency Alerts: https://spike.sh/glossary/latency-alerts/ — Latency Alerts are automated notifications triggered when system response times exceed predefined thresholds.
+- Learning Algorithms for Root Cause Analysis: https://spike.sh/glossary/learning-algorithms-for-root-cause-analysis/ — Learning algorithms for root cause analysis are AI-powered tools that analyze incident data to identify the underlying causes of problems.
+- Level 1 Support (L1): https://spike.sh/glossary/level-1-support-l1/ — Level 1 Support (L1) is the initial tier of technical support that handles basic customer issues and service requests.
+- Level 2 Support (L2): https://spike.sh/glossary/level-2-support-l2/ — Level 2 Support (L2) is the second tier of technical support that handles more complex incidents escalated from L1.
+- Level 3 Support (L3): https://spike.sh/glossary/level-3-support-l3/ — Level 3 Support (L3) is the highest tier of technical support consisting of expert-level specialists who handle the most complex incidents.
+- Live Incident Updates: https://spike.sh/glossary/live-incident-updates/ — Live Incident Updates are real-time communications shared during an active incident that provide stakeholders with current status, progress, and expected resolution times.
+- Log Analysis: https://spike.sh/glossary/log-analysis/ — Log analysis is the process of examining system logs to identify patterns, anomalies, and potential issues that could lead to incidents.
+- Log Monitoring: https://spike.sh/glossary/log-monitoring/ — Log monitoring is the continuous observation of log files to detect issues in real-time.
+- Log-based Anomaly Detection: https://spike.sh/glossary/log-based-anomaly-detection/ — Log-based Anomaly Detection is a monitoring technique that analyzes system logs to identify unusual patterns or behaviors that may indicate incidents.
+- Logging: https://spike.sh/glossary/logging/ — Logging is the practice of recording events, actions, and states within software applications and systems.
+- Low-Code Incident Automation: https://spike.sh/glossary/low-code-incident-automation/ — Low-Code Incident Automation refers to platforms that allow teams to create automated incident response workflows with minimal programming knowledge.
+
+## M
+
+- Machine Learning For Incident Prediction: https://spike.sh/glossary/machine-learning-for-incident-prediction/ — Machine Learning for Incident Prediction uses historical incident data and AI algorithms to forecast potential system failures or service disruptions before they occur, enabling proactive response and prevention.
+- Machine Learning For Root Cause Analysis: https://spike.sh/glossary/machine-learning-for-root-cause-analysis/ — Machine Learning for Root Cause Analysis uses AI algorithms to automatically identify the underlying causes of incidents by analyzing system logs, metrics, and event data to find patterns and correlations that might not be obvious to human analysts.
+- Maintenance Mode: https://spike.sh/glossary/maintenance-mode/ — Maintenance Mode is a planned state for systems or services where they're temporarily taken offline or have limited functionality to allow for updates, repairs, or other maintenance activities without triggering unnecessary alerts or incidents.
+- Major Incident: https://spike.sh/glossary/major-incident/ — A Major Incident is a high-impact, high-urgency event that causes significant disruption to business operations or services.
+- Manual Escalation: https://spike.sh/glossary/manual-escalation/ — Manual escalation is when an on-call responder decides to pass an incident to another team member or a higher-level expert.
+- Mean Time Between Failures (MTBF): https://spike.sh/glossary/mean-time-between-failures-mtbf/ — Mean Time Between Failures (MTBF) is the average time between the start of one incident and the start of the next incident for a specific system or service.
+- Mean Time To Acknowledge (MTTA): https://spike.sh/glossary/mean-time-to-acknowledge-mtta/ — Mean Time to Acknowledge (MTTA) is the average time between when an incident alert is generated and when someone acknowledges receipt of that alert.
+- Mean Time To Detect (MTTD): https://spike.sh/glossary/mean-time-to-detect-mttd/ — Mean Time to Detect (MTTD) is the average time between when an incident actually begins and when it is detected by monitoring systems or users.
+- Mean Time To Diagnose (MTTD): https://spike.sh/glossary/mean-time-to-diagnose-mttd/ — Mean Time to Diagnose (MTTD) is the average time between when an incident is detected and when its root cause is identified.
+- Mean Time To Recovery (MTTR): https://spike.sh/glossary/mean-time-to-recovery-mttr/ — Mean Time to Recovery (MTTR) is the average time between when a system fails and when it returns to full functionality.
+- Mean Time To Resolve (MTTR): https://spike.sh/glossary/mean-time-to-resolve-mttr/ — Mean Time to Resolve (MTTR) is the average time between when an incident is detected and when it is fully resolved.
+- Metrics Dashboard: https://spike.sh/glossary/metrics-dashboard/ — A Metrics Dashboard is a visual interface that displays key incident management performance indicators in real-time, allowing teams to monitor system health, track incident response effectiveness, and identify trends at a glance.
+- Microservices Monitoring: https://spike.sh/glossary/microservices-monitoring/ — Microservices Monitoring is the practice of tracking the health, performance, and interactions of individual microservices within a distributed application architecture to detect issues and understand system behavior.
+- Mobile Alerts: https://spike.sh/glossary/mobile-alerts/ — Mobile Alerts are notifications sent to smartphones or tablets to inform incident response teams about system issues, outages, or other events requiring attention.
+- Mobile-first Incident Response: https://spike.sh/glossary/mobile-first-incident-response/ — Mobile-first Incident Response is an approach to incident management that prioritizes mobile device capabilities for alerting, communication, and resolution, allowing teams to respond effectively regardless of their location.
+- Monitoring: https://spike.sh/glossary/monitoring/ — Monitoring is the continuous observation and checking of IT systems, applications, and infrastructure to detect issues, track performance, and identify anomalies.
+- Monitoring System: https://spike.sh/glossary/monitoring-system/ — A monitoring system is a set of tools and processes that track the health, performance, and availability of IT infrastructure and applications.
+- Monkey Patching: https://spike.sh/glossary/monkey-patching/ — Monkey patching in incident management refers to the practice of making temporary, quick fixes to code or systems during an incident without following standard change procedures.
+- Multi-channel Notifications: https://spike.sh/glossary/multi-channel-notifications/ — Multi-channel Notifications are incident alerts delivered through various communication methods simultaneously or sequentially based on predefined rules.
+- Multi-Cloud Incident Management: https://spike.sh/glossary/multi-cloud-incident-management/ — Multi-cloud Incident Management is the practice of monitoring, detecting, and responding to incidents across multiple cloud providers and environments through a unified approach, tools, and processes.
+- Multi-factor Authentication: https://spike.sh/glossary/multi-factor-authentication/ — Multi-factor Authentication (MFA) is a security method that requires users to provide two or more verification factors to gain access to systems or applications.
+- Mutual Aid Agreement: https://spike.sh/glossary/mutual-aid-agreement/ — A Mutual Aid Agreement is a formal arrangement between organizations to provide assistance to each other during incidents or emergencies that exceed their individual response capabilities.
+
+## N
+
+- National Incident Management System (NIMS): https://spike.sh/glossary/national-incident-management-system-nims/ — The National Incident Management System (NIMS) is a standardized approach to incident management developed by the U.S. Department of Homeland Security.
+- Natural Language Processing For Incident Analysis: https://spike.sh/glossary/natural-language-processing-for-incident-analysis/ — Natural Language Processing (NLP) for incident analysis is the application of AI technology that interprets and analyzes human language in incident reports, chat logs, and documentation.
+- Network Dependency Mapping: https://spike.sh/glossary/network-dependency-mapping/ — Network dependency mapping is the process of documenting and visualizing the relationships between network components, services, and applications.
+- Network Latency: https://spike.sh/glossary/network-latency/ — Network latency is the time delay between sending and receiving data across a network.
+- Network Monitoring: https://spike.sh/glossary/network-monitoring/ — Network monitoring is the systematic process of observing and analyzing network infrastructure to detect performance issues, outages, and security threats.
+- Network Operations Center (NOC): https://spike.sh/glossary/network-operations-center-noc/ — A Network Operations Center (NOC) is a centralized location where IT professionals monitor, manage, and troubleshoot an organization's network infrastructure, systems, and services.
+- Network Outage: https://spike.sh/glossary/network-outage/ — A network outage is a disruption in network connectivity that prevents users from accessing network resources or services.
+- Network Resilience Automation: https://spike.sh/glossary/network-resilience-automation/ — Network resilience automation uses software tools and scripts to automatically detect, diagnose, and recover from network failures without human intervention.
+- Neural Network Monitoring: https://spike.sh/glossary/neural-network-monitoring/ — Neural network monitoring uses artificial intelligence to learn normal system behavior patterns and detect anomalies that traditional threshold-based monitoring might miss.
+- Noise Reduction: https://spike.sh/glossary/noise-reduction/ — Noise reduction in incident management is the practice of filtering out unnecessary alerts and notifications to focus on meaningful signals.
+- Non-Compliance: https://spike.sh/glossary/non-compliance/ — Non-compliance in incident management refers to the failure to adhere to established policies, procedures, or regulatory requirements when handling incidents.
+- Non-Conformance: https://spike.sh/glossary/non-conformance/ — Non-conformance in incident management refers to a deviation from established policies, procedures, or standards during incident handling.
+- Non-Critical Incident: https://spike.sh/glossary/non-critical-incident/ — A non-critical incident is an event that disrupts normal business operations but doesn't significantly impact core services or large numbers of users.
+- Normal Operations: https://spike.sh/glossary/normal-operations/ — Normal operations in incident management refer to the standard functioning of systems and processes without any active incidents or disruptions.
+- Notification: https://spike.sh/glossary/notification/ — A notification is an automated or manual alert sent to individuals or teams about an incident, system change, or important event.
+- Notification Escalation: https://spike.sh/glossary/notification-escalation/ — Notification escalation is a systematic process that automatically routes alerts to different team members or groups based on predefined rules when initial notifications go unacknowledged.
+- Notification Protocol: https://spike.sh/glossary/notification-protocol/ — A notification protocol in incident management is a standardized process for alerting relevant stakeholders about incidents.
+- Notification Routing: https://spike.sh/glossary/notification-routing/ — Notification routing is the process of directing incident alerts to the appropriate individuals or teams based on predefined rules and criteria.
+- Notification Templates: https://spike.sh/glossary/notification-templates/ — Notification templates are standardized formats for incident alerts that contain predefined content, structure, and placeholders for incident-specific information.
+
+## O
+
+- Observability: https://spike.sh/glossary/observability/ — Observability is the ability to understand a system's internal state based on its external outputs.
+- Observability Integration: https://spike.sh/glossary/observability-integration/ — Observability integration is the process of connecting various monitoring tools, logs, metrics, and tracing systems into a unified framework.
+- Observability-Driven Incident Response: https://spike.sh/glossary/observability-driven-incident-response/ — Observability-driven incident response is an approach that uses comprehensive system monitoring and data analysis to quickly identify, diagnose, and resolve incidents.
+- On-Call: https://spike.sh/glossary/oncall/ — On-call is a rotation system where IT professionals remain available outside regular working hours to respond to incidents and alerts.
+- On-Call Calendar: https://spike.sh/glossary/oncall-calendar/ — An on-call calendar is a visual representation of the on-call schedule that shows which team members are responsible for incident response during specific time periods.
+- On-Call Engineer: https://spike.sh/glossary/oncall-engineer/ — An on-call engineer is a team member assigned to respond to incidents and alerts outside regular working hours.
+- On-Call Load: https://spike.sh/glossary/oncall-load/ — On-call load is the number of incidents, alerts, or pages an on-call engineer receives during their shift.
+- On-call load distribution: https://spike.sh/glossary/oncall-load-distribution/ — On-call load distribution is the practice of spreading incident response duties evenly across team members.
+- On-Call Management: https://spike.sh/glossary/oncall-management/ — On-call management is a structured process where IT professionals take turns being available to respond to incidents outside regular working hours.
+- On-Call Override: https://spike.sh/glossary/oncall-override/ — On-call override is a temporary adjustment to an on-call schedule that allows a different team member to take responsibility during a specific time period.
+- On-Call Responder: https://spike.sh/glossary/oncall-responder/ — An on-call responder is a designated IT professional responsible for acknowledging, investigating, and resolving incidents that occur during their assigned shift.
+- On-Call Rotation: https://spike.sh/glossary/oncall-rotation/ — On-call rotation is a system where team members take turns being available to respond to incidents outside regular working hours.
+- On-Call Schedule: https://spike.sh/glossary/oncall-schedule/ — An on-call schedule is a formal rotation plan that designates which team members are responsible for responding to incidents during specific time periods.
+- On-Call Shift: https://spike.sh/glossary/on-call-shift/ — An on-call shift is a set period when a team member is responsible for responding to incidents.
+- Open Telemetry: https://spike.sh/glossary/open-telemetry/ — OpenTelemetry is an open-source observability framework that provides standardized tools, APIs, and SDKs for collecting and exporting metrics, logs, and traces from applications and infrastructure.
+- Operational Analytics: https://spike.sh/glossary/operational-analytics/ — Operational analytics is the process of analyzing data from day-to-day operations to improve efficiency and effectiveness.
+- Operational Dashboard: https://spike.sh/glossary/operational-dashboard/ — An operational dashboard is a visual display that shows real-time data about the current state of IT systems and services.
+- Operational Intelligence: https://spike.sh/glossary/operational-intelligence/ — Operational intelligence is the real-time analysis of data from various sources to provide insights into business operations and incident management.
+- Operational Maturity (OM): https://spike.sh/glossary/operational-maturity-om/ — Operational Maturity (OM) is a framework that measures how advanced an organization's operational practices and processes are in terms of effectiveness, efficiency, and consistency.
+- Operational Readiness: https://spike.sh/glossary/operational-readiness/ — Operational Readiness is the state of preparedness that allows an organization to effectively respond to and manage incidents when they occur.
+- Operational Resilience: https://spike.sh/glossary/operational-resilience/ — Operational Resilience is an organization's ability to continue delivering critical services despite disruptive incidents.
+- Operations: https://spike.sh/glossary/operations/ — Operations in incident management refers to the day-to-day activities and processes that maintain IT services and infrastructure.
+- Operations Bridge: https://spike.sh/glossary/operations-bridge/ — Operations Bridge is a centralized function that provides real-time monitoring, coordination, and management of IT services across an organization.
+- Operations Lead: https://spike.sh/glossary/operations-lead/ — An Operations Lead is the individual responsible for overseeing daily IT operations, coordinating operational activities, and ensuring service reliability.
+- Outage: https://spike.sh/glossary/outage/ — An outage is an unplanned interruption or loss of service in a system, network, application, or infrastructure component that prevents users from accessing resources or performing normal operations.
+- Outage Tracking: https://spike.sh/glossary/outage-tracking/ — Outage tracking is the systematic monitoring and documentation of service disruptions within an IT environment.
+- Outcome-Based Incident Management: https://spike.sh/glossary/outcome-based-incident-management/ — Outcome-based incident management focuses on achieving specific, measurable results rather than just following predefined processes.
+
+## P
+
+- P0 (Priority Zero): https://spike.sh/glossary/p0-priority-zero/ — P0 is the highest incident priority level, representing critical incidents that cause complete service outage or pose severe security threats.
+- P1 (Priority One): https://spike.sh/glossary/p1-priority-one/ — P1 is the second-highest incident priority level, representing serious incidents that cause significant service degradation or affect a large portion of users.
+- P2 (Priority Two): https://spike.sh/glossary/p2-priority-two/ — P2 is a moderate priority level for incidents that cause limited service disruption or affect a smaller subset of users.
+- P3 (Priority Three): https://spike.sh/glossary/p3-priority-three/ — P3 is a low-priority incident level that represents minor issues with limited impact on users or business operations.
+- P4 (Priority Four): https://spike.sh/glossary/p4-priority-four/ — P4 is the lowest incident priority level, representing trivial issues that have minimal or no impact on users or business operations.
+- Phone Call Notifications: https://spike.sh/glossary/phone-call-notifications/ — Phone Call Notifications are automated voice calls sent to on-call responders when critical incidents occur.
+- Platform Engineering: https://spike.sh/glossary/platform-engineering/ — Platform engineering is the discipline of designing and building internal developer platforms that enable software delivery and operations teams to self-service their infrastructure needs.
+- Platform Integration: https://spike.sh/glossary/platform-integration/ — Platform Integration in incident management refers to connecting your incident response tools with other systems like monitoring, ticketing, communication, and development platforms.
+- Playbook: https://spike.sh/glossary/playbook/ — A Playbook is a documented set of procedures and steps that guide teams through the process of responding to specific types of incidents.
+- Post-Incident Review (PIR): https://spike.sh/glossary/post-incident-review-pir/ — A Post-Incident Review (PIR) is a structured analysis conducted after an incident has been resolved to understand what happened, why it happened, and how to prevent similar incidents in the future.
+- Postmortem: https://spike.sh/glossary/postmortem/ — A postmortem in incident management is a structured review conducted after an incident is resolved to analyze what happened, why it happened, and how to prevent similar incidents in the future.
+- Postmortem Templates: https://spike.sh/glossary/postmortem-templates/ — Postmortem Templates are standardized documents or forms used to analyze incidents after they've been resolved.
+- Predictable Pricing: https://spike.sh/glossary/predictable-pricing/ — Predictable pricing is a transparent billing model for incident management tools where costs remain consistent and foreseeable regardless of usage fluctuations.
+- Predictive Analytics: https://spike.sh/glossary/predictive-analytics/ — Predictive analytics in incident management uses historical data, statistical algorithms, and machine learning techniques to identify patterns and predict future incidents before they occur.
+- Preventive Action: https://spike.sh/glossary/preventive-action/ — Preventive Action is a proactive measure taken to eliminate the cause of a potential incident before it occurs.
+- Preventive Intelligence: https://spike.sh/glossary/preventive-intelligence/ — Preventive intelligence is the systematic collection and analysis of data to identify potential incidents before they occur.
+- Primary Responder: https://spike.sh/glossary/primary-responder/ — A primary responder is the first person or team assigned to handle an incident as soon as it is reported.
+- Priority: https://spike.sh/glossary/priority/ — Priority in incident management is the assigned level of urgency and importance given to an incident based on its impact on business operations and customers.
+- Priority Automation: https://spike.sh/glossary/priority-automation/ — Priority Automation is a feature in incident management systems that automatically assigns priority levels to incidents based on predefined rules and criteria.
+- Priority Detection: https://spike.sh/glossary/priority-detection/ — Priority detection is the process of automatically assessing and assigning priority levels to incidents based on predefined criteria and real-time data.
+- Priority Matrix: https://spike.sh/glossary/priority-matrix/ — A priority matrix in incident management is a visual tool that helps teams categorize incidents based on their impact and urgency.
+- Proactive Alerts: https://spike.sh/glossary/proactive-alerts/ — Proactive Alerts are notifications generated by monitoring systems before an incident occurs or reaches critical status.
+- Proactive Incident Response: https://spike.sh/glossary/proactive-incident-response/ — Proactive incident response is an approach that focuses on preventing incidents before they occur rather than just reacting to them.
+- Proactive Monitoring: https://spike.sh/glossary/proactive-monitoring/ — Proactive Monitoring is the practice of continuously checking IT systems and infrastructure to detect potential issues before they cause service disruptions.
+- Proactive Response: https://spike.sh/glossary/proactive-response/ — Proactive Response is an approach to incident management where teams take action to address potential issues before they escalate into service-impacting incidents.
+- Problem Management: https://spike.sh/glossary/problem-management/ — Problem management is the process of identifying, analyzing, and resolving the underlying causes of recurring incidents.
+- Problem Record: https://spike.sh/glossary/problem-record/ — A Problem Record is a formal documentation that captures the details of an underlying issue causing one or more incidents in IT systems.
+- Process Automation: https://spike.sh/glossary/process-automation/ — Process automation in incident management involves using technology to automatically execute routine response tasks without human intervention.
+- Production Environment: https://spike.sh/glossary/production-environment/ — A Production Environment is the live system where applications and services run to deliver functionality to end-users.
+
+## Q
+
+- Quality Assurance: https://spike.sh/glossary/quality-assurance/ — Quality Assurance in incident management is a proactive process that focuses on preventing incidents by improving systems, processes, and practices.
+- Quality Control: https://spike.sh/glossary/quality-control/ — Quality Control in incident management is the process of monitoring and evaluating the effectiveness of incident response activities.
+- Quality Management System (QMS): https://spike.sh/glossary/quality-management-system-qms/ — A Quality Management System (QMS) in incident management is a formalized system that documents processes, procedures, and responsibilities for achieving quality policies and objectives.
+- Quantitative Analysis: https://spike.sh/glossary/quantitative-analysis/ — Quantitative Analysis in incident management involves using mathematical and statistical methods to analyze incident data.
+- Quantitative Incident Analytics: https://spike.sh/glossary/quantitative-incident-analytics/ — Quantitative incident analytics is the practice of collecting, measuring, and analyzing numerical data related to incidents to identify patterns, trends, and areas for improvement in incident management processes.
+- Quantitative Risk Assessment (QRA): https://spike.sh/glossary/quantitative-risk-assessment-qra/ — Quantitative Risk Assessment (QRA) in incident management is a method of evaluating risks using numerical and statistical techniques.
+- Quantum Computing Security Incidents: https://spike.sh/glossary/quantum-computing-security-incidents/ — Quantum computing security incidents are breaches or vulnerabilities that emerge from quantum computing technologies or target quantum systems.
+- Quantum-resistant Encryption: https://spike.sh/glossary/quantum-resistant-encryption/ — Quantum-resistant encryption refers to cryptographic algorithms designed to withstand attacks from quantum computers.
+- Query Builder: https://spike.sh/glossary/query-builder/ — Query Builder is a tool that allows users to create custom searches and filters for incident data without needing to know complex query languages.
+- Queue: https://spike.sh/glossary/queue/ — A queue in incident management is an organized list of incidents waiting to be addressed by support teams.
+- Queue Management: https://spike.sh/glossary/queue-management/ — Queue Management is the systematic process of organizing, prioritizing, and tracking incidents as they move through the resolution lifecycle.
+- Queue Prioritization: https://spike.sh/glossary/queue-prioritization/ — Queue prioritization is a method used in incident management to organize and handle incoming incidents based on their urgency, impact, and business importance.
+- Quick Actions: https://spike.sh/glossary/quick-actions/ — Quick Actions are predefined, one-click operations that allow incident responders to perform common tasks without navigating through multiple screens or systems.
+- Quick Response: https://spike.sh/glossary/quick-reponse/ — Quick Response in incident management is the rapid acknowledgment and initial action taken to address an incident as soon as it's detected.
+
+## R
+
+- Real-time Alerts: https://spike.sh/glossary/real-time-alerts/ — Real-time alerts are immediate notifications triggered when monitoring systems detect anomalies, threshold violations, or potential incidents.
+- Real-time Collaboration Tools: https://spike.sh/glossary/real-time-collaboration-tools/ — Real-time collaboration tools are software platforms that allow incident response teams to work together simultaneously during an incident.
+- recovery: https://spike.sh/glossary/recovery/ — Recovery in incident management is the process of restoring systems, services, or operations back to normal functioning after an incident or outage.
+- Recovery Plan: https://spike.sh/glossary/recovery-plan/ — A recovery plan is a documented set of procedures designed to restore systems and services after an incident.
+- Recovery Point Objective (RPO): https://spike.sh/glossary/recovery-point-objective-rpo/ — Recovery Point Objective (RPO) is the maximum acceptable amount of data loss measured in time.
+- Recovery Time Objective (RTO): https://spike.sh/glossary/recovery-time-objective-rto/ — Recovery Time Objective (RTO) is the maximum acceptable time it should take to restore a system after an incident.
+- Release Management: https://spike.sh/glossary/release-management/ — Release management is the process of planning, scheduling, and controlling software builds through different environments to production.
+- Remote Incident Response: https://spike.sh/glossary/remote-incident-response/ — Remote incident response is the practice of managing and resolving incidents without requiring physical presence at the affected systems.
+- Resilience: https://spike.sh/glossary/resilience/ — Resilience in incident management is the ability of an IT system or organization to withstand, adapt to, and rapidly recover from disruptions while maintaining continuous business operations.
+- Resilience Engineering: https://spike.sh/glossary/resilience-engineering/ — Resilience engineering is an approach to incident management that focuses on building systems that can withstand, adapt to, and recover from failures.
+- Resolution Time: https://spike.sh/glossary/resolution-time/ — Resolution time is the total duration from when an incident is first detected until it is fully resolved and normal service is restored.
+- Resolution Tracking: https://spike.sh/glossary/resolution-tracking/ — Resolution tracking is the process of monitoring and documenting the progress of incident remediation from detection to closure.
+- Resolve: https://spike.sh/glossary/resolve/ — Resolve in incident management refers to the process of fixing an issue and returning affected systems to normal operation.
+- Response Automation: https://spike.sh/glossary/response-automation/ — Response automation refers to the use of technology to automatically execute predefined actions when an incident occurs, without requiring human intervention.
+- Response Time: https://spike.sh/glossary/response-time/ — Response time in incident management is the duration between incident detection and the beginning of remediation efforts.
+- Risk Analysis: https://spike.sh/glossary/risk-analysis/ — Risk analysis in incident management is the systematic process of identifying potential threats, vulnerabilities, and their possible impacts on IT systems and services.
+- Risk Management: https://spike.sh/glossary/risk-management/ — Risk management in incident management is the coordinated set of activities to direct and control an organization regarding risk.
+- Risk Prediction with AI: https://spike.sh/glossary/risk-prediction-with-ai/ — Risk Prediction with AI is the application of artificial intelligence and machine learning algorithms to analyze historical incident data, system metrics, and environmental factors to forecast potential incidents before they occur.
+- Risk Register: https://spike.sh/glossary/risk-register/ — A risk register is a document that records identified risks in incident management, their severity, likelihood of occurrence, potential impact, and mitigation strategies.
+- Robotic Process Automation (RPA): https://spike.sh/glossary/robotic-process-automation-rpa/ — Robotic Process Automation (RPA) in Incident Management is the use of software robots or "bots" to automate repetitive, rule-based tasks in the incident response process.
+- Role-based Access Control: https://spike.sh/glossary/role-based-access-control/ — Role-based Access Control (RBAC) is a method of restricting system access based on the roles of individual users within an organization.
+- Root Cause: https://spike.sh/glossary/root-cause/ — Root cause is the fundamental, underlying reason for an incident or problem.
+- Root Cause Analysis (RCA): https://spike.sh/glossary/root-cause-analysis-rca/ — Root Cause Analysis (RCA) is a systematic process for identifying the fundamental cause of an incident or problem.
+- Runbook: https://spike.sh/glossary/runbook/ — A runbook is a standardized document that contains step-by-step procedures for responding to specific incidents or performing routine operations.
+
+## S
+
+- Scheduled Maintenance: https://spike.sh/glossary/scheduled-maintenance/ — Scheduled Maintenance is planned downtime for systems or services to perform updates, patches, hardware replacements, or other preventive work.
+- Secondary Responder: https://spike.sh/glossary/secondary-responder/ — A secondary responder is a backup team member who steps in if the primary on-call responder cannot address an incident.
+- Security Incident: https://spike.sh/glossary/security-incident/ — A security incident is an event that violates security policies, compromises data integrity, or threatens system confidentiality or availability.
+- Security Incident Response: https://spike.sh/glossary/security-incident-response/ — Security Incident Response is a structured approach to handling and managing the aftermath of a security breach or cyberattack.
+- Self-Healing Incident: https://spike.sh/glossary/self-healing-incident/ — A self-healing incident is an issue that is detected and resolved automatically by systems without human intervention.
+- Self-healing Systems: https://spike.sh/glossary/self-healing-systems/ — Self-healing Systems are IT infrastructures designed to automatically detect, diagnose, and fix problems without human intervention.
+- Sentiment Analysis for Customer Impact: https://spike.sh/glossary/sentiment-analysis-for-customer-impact/ — Sentiment Analysis for Customer Impact is a technique that uses natural language processing to analyze customer feedback during incidents to gauge their emotional response and satisfaction levels.
+- Serverless Incident Management: https://spike.sh/glossary/server-incident-management/ — Serverless Incident Management is an approach to handling IT incidents using cloud-based serverless computing platforms.
+- Service: https://spike.sh/glossary/service/ — A service in incident management refers to any application, system, or infrastructure component that delivers value to users.
+- Service Degradation: https://spike.sh/glossary/service-degradation/ — Service degradation occurs when a system continues to function but with reduced performance, reliability, or capabilities.
+- Service Dependency Visualization: https://spike.sh/glossary/service-dependency-visualization/ — Service Dependency Visualization is a graphical representation of how different services, applications, and infrastructure components depend on each other within an IT environment.
+- Service Desk: https://spike.sh/glossary/service-desk/ — A Service Desk is the primary point of contact between users and IT support for incident reporting and resolution.
+- Service Impact: https://spike.sh/glossary/service-impact/ — Service impact refers to the effect an incident has on business operations, user experience, or system functionality.
+- Service Level Agreement (SLA): https://spike.sh/glossary/service-level-agreement-sla/ — A Service Level Agreement (SLA) is a contract between a service provider and a customer that defines the expected level of service.
+- Service Level Indicator (SLI): https://spike.sh/glossary/service-level-indicator-sli/ — A Service Level Indicator (SLI) is a specific metric used to measure the performance of a service.
+- Service Level Objective (SLO): https://spike.sh/glossary/service-level-objective-slo/ — A Service Level Objective (SLO) is a target value or range for a service level that is measured by a Service Level Indicator (SLI).
+- Service Mapping: https://spike.sh/glossary/service-mapping/ — Service Mapping is the process of documenting relationships between business services and their underlying IT components.
+- Service Mapping Dashboard: https://spike.sh/glossary/service-mapping-dashboard/ — A Service Mapping Dashboard is a visual tool that displays the relationships and dependencies between different IT services, applications, and infrastructure components within an organization.
+- Service Mesh Observability: https://spike.sh/glossary/service-mesh-observability/ — Service Mesh Observability refers to the ability to gain visibility into the behavior, performance, and health of microservices within a service mesh architecture.
+- Service Owner: https://spike.sh/glossary/service-owner/ — A service owner is the individual responsible for the overall health, performance, and business alignment of a specific service.
+- Service Restoration: https://spike.sh/glossary/service-restoration/ — Service Restoration is the process of returning affected systems to normal operation after an incident.
+- Severity: https://spike.sh/glossary/severity/ — Severity in incident management is a measure of the impact and urgency of an incident on business operations, services, or customers.
+- Severity Automation: https://spike.sh/glossary/severity-automation/ — Severity Automation is the process of using predefined rules and algorithms to automatically assign severity levels to incidents based on their characteristics.
+- Shadow On-Call Rotation: https://spike.sh/glossary/shadow-on-call-rotation/ — Shadow on-call rotation lets new team members observe experienced engineers during on-call shifts without full responsibility.
+- Single Point of Failure (SPOF): https://spike.sh/glossary/single-point-of-failure-spof/ — A Single Point of Failure (SPOF) is a component within an IT system that, if it fails, will cause the entire system to stop functioning.
+- Single Point Of Failure (SPOF): https://spike.sh/glossary/single-point-of-failure/ — A single point of failure (SPOF) is any part of a system that, if it fails, will cause the entire system or service to stop working.
+- Site Reliability Engineering (SRE): https://spike.sh/glossary/site-reliability-engineering-sre/ — Site Reliability Engineering (SRE) is a discipline that incorporates aspects of software engineering and applies them to infrastructure and operations problems.
+- SRE as a Service: https://spike.sh/glossary/sre-as-a-service/ — SRE as a Service is a model where organizations outsource Site Reliability Engineering functions to specialized third-party providers.
+- Stakeholder: https://spike.sh/glossary/stakeholder/ — A stakeholder in incident management is any individual, team, or entity affected by or having influence over an incident and its resolution.
+- Standard Operating Procedure (SOP): https://spike.sh/glossary/standard-operating-procedure/ — A Standard Operating Procedure (SOP) in incident management is a documented set of step-by-step instructions that guide teams through handling specific types of incidents.
+- Status Page: https://spike.sh/glossary/status-page/ — A Status Page is a dedicated webpage that displays the current operational status of an organization's services, applications, and infrastructure.
+- Support Tier: https://spike.sh/glossary/support-tier/ — Support tiers in incident management are hierarchical levels of technical expertise and authority used to organize incident response.
+- Suppression Rules: https://spike.sh/glossary/suppression-rules/ — Suppression Rules are conditions that prevent alerts from being generated or sent to responders when certain criteria are met.
+- Swarming: https://spike.sh/glossary/swarming/ — Swarming is an incident response approach where multiple specialists collaborate simultaneously on an incident rather than following traditional tiered escalation.
+- Synthetic Monitoring: https://spike.sh/glossary/synthetic-monitoring/ — Synthetic Monitoring is a proactive monitoring technique that simulates user interactions with systems and applications to detect problems before real users encounter them.
+- System Failure: https://spike.sh/glossary/system-failure/ — System failure is when a critical part of your IT infrastructure stops working as expected.
+- System Outage: https://spike.sh/glossary/system-outage/ — A system outage is a period when a computer system, service, or application becomes unavailable or non-functional for its intended users.
+
+## T
+
+- Teams (Multi) Management: https://spike.sh/glossary/teams-multi-management/ — Teams (multi) management refers to the coordination and oversight of multiple teams involved in incident response.
+- Technical Debt: https://spike.sh/glossary/technical-debt/ — Technical debt in incident management refers to the accumulated consequences of taking shortcuts or delaying improvements in monitoring, alerting, and response systems.
+- Technical Support: https://spike.sh/glossary/technical-support/ — Technical Support refers to a service that provides assistance to users experiencing technical problems with hardware, software, or other computer-related issues.
+- Telemetry-Based Incident Detection: https://spike.sh/glossary/telemetry-based-incident-detection/ — Telemetry-based incident detection uses real-time data collected from various systems and devices to identify potential security incidents.
+- TEM (Threat and Error Management): https://spike.sh/glossary/threat-and-error-management/ — Threat and Error Management (TEM) is a proactive approach to identifying and mitigating potential threats and errors in operational environments.
+- Template Library: https://spike.sh/glossary/template-library/ — A template library is a collection of pre-defined, customizable documents and workflows for common incident types and communications.
+- Threat: https://spike.sh/glossary/threat/ — In incident management, a threat is any potential danger that could exploit vulnerabilities in a system, leading to unauthorized access, data breaches, service disruptions, or other harmful outcomes.
+- Threat Intelligence: https://spike.sh/glossary/threat-intelligence/ — Threat intelligence is the collection, analysis, and dissemination of information about potential or current threats to an organization's digital assets.
+- Threat Management: https://spike.sh/glossary/threat-management/ — Threat Management is the systematic process of identifying, assessing, and mitigating potential security threats to an organization's systems, data, and operations.
+- Threshold: https://spike.sh/glossary/threshold/ — A threshold is a predefined limit or boundary that, when crossed, triggers an alert or incident.
+- Ticket: https://spike.sh/glossary/ticket/ — A ticket is a digital record of an incident, alert, or service request within an IT system.
+- Ticket Automation: https://spike.sh/glossary/ticket-automation/ — Ticket automation is a process that uses software to automatically create, route, and manage support tickets without human intervention.
+- Ticket Management: https://spike.sh/glossary/ticket-management/ — Ticket management is the overall process of handling incident tickets throughout their lifecycle.
+- Tier 1/2/3 Support: https://spike.sh/glossary/tier-1-2-3-support/ — Tier 1/2/3 Support is a structured approach to technical support that organizes teams into levels of expertise.
+- Time to Acknowledge: https://spike.sh/glossary/time-to-acknowledge/ — Time to Acknowledge is the duration between when an incident alert is triggered and when a team member acknowledges receipt of that alert.
+- Time To Detect: https://spike.sh/glossary/time-to-detect/ — Time to Detect, or Mean Time to Detect (MTTD), measures the average time elapsed between when an incident begins and when your team first detects or identifies it.
+- Time To Resolution: https://spike.sh/glossary/time-to-resolution/ — Time to Resolution, often called Mean Time to Resolution (MTTR), is the average time taken to completely fix an incident after it has been reported.
+- Time to Respond: https://spike.sh/glossary/time-to-respond/ — Time to Respond is the duration between when an incident is acknowledged and when active troubleshooting or remediation work begins.
+- Timeline View: https://spike.sh/glossary/timeline-view/ — Timeline view is a visual representation of incident-related events in chronological order.
+- Total Cost Of Ownership (TCO): https://spike.sh/glossary/total-cost-of-ownership-tco/ — Total Cost of Ownership (TCO) in incident management is a comprehensive financial assessment that accounts for all direct and indirect costs associated with implementing and maintaining incident management systems and processes throughout their lifecycle.
+- Triage: https://spike.sh/glossary/triage/ — Triage is the process of quickly assessing and prioritizing incoming incidents or alerts.
+- Triage Automation: https://spike.sh/glossary/triage-automation/ — Triage automation is the use of AI and machine learning to automatically assess, categorize, and prioritize incoming incidents or alerts.
+- Trigger: https://spike.sh/glossary/trigger/ — A trigger in incident management is an event or condition that initiates an automated response or alert.
+- Troubleshooting: https://spike.sh/glossary/troubleshooting/ — Troubleshooting is the systematic process of identifying, diagnosing, and resolving problems within systems or applications.
+
+## U
+
+- Unified AIOps: https://spike.sh/glossary/unified-aiops/ — Unified AIOps is an approach that combines artificial intelligence, machine learning, and automation to integrate data from multiple IT monitoring tools into a single, comprehensive view.
+- Unified Communications: https://spike.sh/glossary/unified-communications/ — Unified Communications is an integrated framework that combines multiple communication tools and channels into a single, cohesive platform.
+- Unified Monitoring: https://spike.sh/glossary/unified-monitoring/ — Unified Monitoring is a comprehensive approach that consolidates monitoring of diverse IT infrastructure, applications, and services into a single platform.
+- Unified Observability: https://spike.sh/glossary/unified-observability/ — Unified observability is an approach that consolidates metrics, logs, traces, and other monitoring data into a single platform for comprehensive visibility across IT environments.
+- Unplanned Downtime: https://spike.sh/glossary/unplanned-downtime/ — Unplanned downtime occurs when systems fail unexpectedly, disrupting business operations.
+- Unplanned Maintenance: https://spike.sh/glossary/unplanned-maintenance/ — Unplanned maintenance, also known as corrective or reactive maintenance, refers to repair work that occurs unexpectedly due to sudden equipment failures or system malfunctions.
+- Unresolved Incident: https://spike.sh/glossary/unresolved-incident/ — An unresolved incident is an IT service disruption that remains active in the incident management system without a solution or workaround.
+- Uptime: https://spike.sh/glossary/uptime/ — Uptime measures how long services are functional without interruptions.
+- Uptime Percentage: https://spike.sh/glossary/uptime-percentage/ — Uptime is calculated as operational time divided by total possible time, expressed in percentages.
+- Uptime SLA: https://spike.sh/glossary/uptime-sla/ — An Uptime SLA (Service Level Agreement) is a contractual commitment that defines the minimum acceptable level of system availability.
+- Urgency Classification: https://spike.sh/glossary/urgency-classification/ — Urgency classification is the process of categorizing incidents based on how quickly they require resolution.
+- User Experience: https://spike.sh/glossary/user-experience/ — User experience in incident management refers to how end users perceive and interact with services during and after an incident.
+- User Experience Monitoring: https://spike.sh/glossary/user-experience-monitoring/ — User Experience Monitoring is the process of tracking and analyzing how users interact with applications and websites from their perspective.
+- User Impact: https://spike.sh/glossary/user-impact/ — User impact is the measure of how an incident affects end users' ability to access services, perform tasks, or achieve their goals.
+- User Management: https://spike.sh/glossary/user-management/ — User management in incident management is the process of creating, controlling, and deleting user accounts within incident response systems.
+- User Permissions: https://spike.sh/glossary/user-permissions/ — User permissions in incident management are specific access rights granted to individuals based on their roles and responsibilities.
+
+## V
+
+- Value Stream Incident Analysis: https://spike.sh/glossary/value-stream-incident-analysis/ — Value Stream Incident Analysis applies value stream mapping principles to the incident management lifecycle.
+- Vendor Incident: https://spike.sh/glossary/vendor-incident/ — A vendor incident is an undesirable event or situation caused by or involving a third-party service provider.
+- Vendor Management: https://spike.sh/glossary/vendor-management/ — Vendor management is the process of selecting, overseeing, and maintaining relationships with third-party service providers.
+- Version Control: https://spike.sh/glossary/version-control/ — Version control is a system that records changes to files over time, allowing you to track modifications, compare versions, and revert to previous states if needed.
+- VIP Alert Routing: https://spike.sh/glossary/vip-alert-routing/ — VIP Alert Routing is a specialized incident management process that directs alerts related to high-priority customers, executives, or critical systems to designated response teams or individuals.
+- Virtual Incident Command Center: https://spike.sh/glossary/virtual-incident-command-center/ — A Virtual Incident Command Center (VICC) is a digital environment used to coordinate incident response activities.
+- Virtual Incident Response Team: https://spike.sh/glossary/virtual-response-team/ — A Virtual Incident Response Team is a group of experts who collaborate remotely to manage and respond to incidents across different locations.
+- Virtual Reality Incident Response: https://spike.sh/glossary/virtual-reality-incident-response/ — Virtual Reality Incident Response uses immersive VR technology to simulate incident scenarios for training or to provide visualization of complex incidents during actual response.
+- Virtual Responder: https://spike.sh/glossary/virtual-responder/ — A Virtual Responder is a digital entity or automated system that responds to incidents without human intervention.
+- Virtual War Room: https://spike.sh/glossary/virtual-war-room/ — A virtual war room is an online collaborative space where incident responders and stakeholders gather to work through major incidents.
+- Visibility: https://spike.sh/glossary/visibility/ — Visibility in incident management refers to the ability to detect, monitor, and understand what's happening across your IT environment.
+- Visibility Controls: https://spike.sh/glossary/visibility-controls/ — Visibility Controls are settings and permissions that determine who can view incident information within an organization.
+- Visualization Dashboard: https://spike.sh/glossary/visualization-dashboard/ — A visualization dashboard in incident management is a graphical interface that displays real-time data about ongoing incidents, response efforts, and key performance indicators.
+- Voice Alert Configuration: https://spike.sh/glossary/voice-alert-configuration/ — Voice Alert Configuration is the setup and management of phone call notifications within an incident management system.
+- Voice Communication: https://spike.sh/glossary/voice-communication/ — Voice communication in incident management refers to the use of verbal interactions, typically through phone calls or voice-over-IP systems, to coordinate responses during critical events.
+- Voice-Activated Incident Management: https://spike.sh/glossary/voice-activated-incident-management/ — Voice-Activated Incident Management uses voice commands to interact with incident management systems.
+- Vulnerability: https://spike.sh/glossary/vulnerability/ — A vulnerability is a weakness in a computer system, network, or application that can be exploited by cybercriminals to gain unauthorized access.
+- Vulnerability Management: https://spike.sh/glossary/vulnerability-management/ — Vulnerability management is a structured, continuous process that identifies, assesses, prioritizes, and remedies security weaknesses in IT systems before they can be exploited.
+- Vulnerability Prediction: https://spike.sh/glossary/vulnerability-prediction/ — Vulnerability Prediction uses data analysis and machine learning to forecast the likelihood that a specific software vulnerability will be exploited.
+
+## W
+
+- War Room: https://spike.sh/glossary/war-room/ — War rooms bring teams together in one space to solve critical incidents through real-time collaboration.
+- Warm Standby: https://spike.sh/glossary/warm-standby/ — Warm standby keeps a backup system updated and ready to manually activate when the primary system fails.
+- Warning: https://spike.sh/glossary/warning/ — Warnings alert teams to potential threats before they become full incidents requiring response.
+- Waterfall Method: https://spike.sh/glossary/waterfall-method/ — Waterfall method handles incidents in a structured sequence requiring full completion of each step first.
+- Web3 Incident Management: https://spike.sh/glossary/web3-incident-management/ — Web3 Incident Management helps teams quickly find and resolve incidents in blockchain systems.
+- Webhook: https://spike.sh/glossary/webhook/ — Webhooks send automatic alerts between apps during incidents for faster response and better tool integration.
+- Weekly Incident Reports: https://spike.sh/glossary/weekly-incident-reports/ — Structured summaries document all incidents and their details over a seven-day period.
+- Weekly Rotation: https://spike.sh/glossary/weekly-rotation/ — Weekly rotation is a scheduling method where on-call or first responder duties change hands every week.
+- Well-Being Features: https://spike.sh/glossary/well-being-features/ — Well-being features in incident management are tools and policies that support the mental and physical health of on-call engineers.
+- Widespread Outage: https://spike.sh/glossary/widespread-outage/ — Large-scale disruptions impacting many users and critical services across multiple locations.
+- Work Log: https://spike.sh/glossary/work-log/ — Incident work logs document response steps in time order to help teams learn from past events.
+- Workflow Automation: https://spike.sh/glossary/workflow-automation/ — Workflow automation streamlines incident management by handling tasks automatically without human input.
+- Workflow Builder: https://spike.sh/glossary/workflow-builder/ — A tool that helps teams automate and standardize their incident management processes.
+- Workflow Engine: https://spike.sh/glossary/workflow-engine/ — Workflow engines execute steps, manage task flow, and track state in incident response processes.
+- Workflow Intelligence: https://spike.sh/glossary/workflow-intelligence/ — Workflow intelligence uses AI to optimize incident processes by identifying patterns and suggesting fixes.
+- Workflow Orchestration: https://spike.sh/glossary/workflow-orchestration/ — Incident management workflow orchestration automates response tasks to speed resolution and reduce manual work.
+- Workflow Template: https://spike.sh/glossary/workflow-template/ — Incident workflow templates guide teams through standard response steps with clear roles and actions.
+- Workload Management: https://spike.sh/glossary/workload-management/ — Effective incident workload management prevents team burnout while maximizing response efficiency.
+
+## X
+
+- X-Team: https://spike.sh/glossary/x-team-cross-functional-team/ — X-Teams blend diverse skills from different departments to tackle complex incidents together.
+- XOps: https://spike.sh/glossary/xops-cross-operational-practices/ — XOps brings together DevOps, SecOps, AIOps and other ops practices to break down silos for better systems.
+
+## Y
+
+- Yearly Incident Review: https://spike.sh/glossary/yearly-incident-review/ — A Yearly Incident Review examines major incidents to find patterns and improve processes.
+- Yearly Incident Trends: https://spike.sh/glossary/yearly-incident-trends/ — Yearly Incident Trends show how incidents change in number, type, and impact over time.
+- Yearly Maintenance Window: https://spike.sh/glossary/yearly-maintenance-window/ — A yearly maintenance window is a set time for system updates and repairs that need longer downtime.
+- YOY (Year-Over-Year) Incident Analysis: https://spike.sh/glossary/yoy-year-over-year-incident-analysis/ — YOY Incident Analysis tracks how incident patterns change from one year to the next to spot trends.
+
+## Z
+
+- Zero Downtime: https://spike.sh/glossary/zero-downtime/ — Zero downtime deployment lets you update software while keeping services running without interrupting users.
+- Zero Latency Detection: https://spike.sh/glossary/zero-latency-detection/ — Zero Latency Detection identifies incidents instantly for quick responses to prevent operational issues.
+- Zero Ops: https://spike.sh/glossary/zero-ops/ — ZeroOps creates self-managing systems that handle app deployment and operations autonomously.
+- Zero Touch Automation: https://spike.sh/glossary/zero-touch-automation/ — Zero Touch Automation uses AI to automate IT tasks without human intervention.
+- Zero Trust Architecture: https://spike.sh/glossary/zero-trust-architecture-zta/ — Zero Trust for incidents means verify all access, assume breaches, and monitor to limit lateral movement.
+- Zero Trust Security: https://spike.sh/glossary/zero-trust-security/ — Zero Trust Security verifies every user and device before granting access, assuming no automatic trust anywhere.
+- Zero-Day Vulnerability: https://spike.sh/glossary/zero-day-vulnerability/ — A zero-day vulnerability is an unknown software flaw that hackers exploit before developers can fix it.
+- Zero-Noise Alerting: https://spike.sh/glossary/zero-noise-alerting/ — Zero-Noise Alerting reduces false positives and alert fatigue by focusing SOC attention on real threats.
+- Zombie Server: https://spike.sh/glossary/zombie-server/ — A zombie server is an idle unnoticed computer that wastes power and space in a data center
+- Zone-Based Recovery: https://spike.sh/glossary/zone-based-recovery/ — Zone-based recovery divides systems into zones for faster, prioritized disaster recovery.
+- Zone-Based Routing: https://spike.sh/glossary/zone-based-routing/ — Zone-Based Routing controls network traffic and security by defining zones with specific trust levels.


### PR DESCRIPTION
## Summary
- Adds `src/llms.txt`, listing all 549 glossary terms grouped alphabetically (term, URL, one-sentence definition), per the [llms.txt convention](https://llmstxt.org/).
- Content is generated from each term's own frontmatter `excerpt`, not the `glossary_terms - sorted_glossary_terms.csv`, since the CSV is stale (524 rows vs. 549 source files) and has 3 blank excerpts that the frontmatter fills in.
- Adds a passthrough copy entry in `.eleventy.js` since `.txt` isn't a configured template format and wouldn't otherwise be copied to `_site/`.
- Verified locally: `npx @11ty/eleventy` builds and produces `_site/llms.txt` correctly.
- All 549 linked term URLs were checked live and return 200.

## Test plan
- [x] Local build produces `_site/llms.txt`
- [ ] Confirm `https://spike.sh/glossary/llms.txt` serves correctly after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)